### PR TITLE
ปรับเมนู backtest signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,6 @@
 - เพิ่มสคริปต์ `main.py` สำหรับ NICEGOLD Assistant โหมด CLI และเพิ่มการทดสอบเมนู
 ### 2025-05-29
 - แก้ไขฟังก์ชัน `maximize_ram` และลบโค้ด `fold_pbar` ที่ไม่จำเป็นใน `main.py`
+### 2025-05-30
+- ปรับเมนู Backtest จาก Signal ให้สร้างฟีเจอร์และใช้ `run_walkforward_backtest`
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-05-30
+- เมนู Backtest จาก Signal ใช้ walk-forward backtest และบันทึกไฟล์ผลลัพธ์
+
 ## 2025-05-28
 - เพิ่มสคริปต์ `main.py` สำหรับ NICEGOLD Assistant โหมด CLI
 - เพิ่ม unit test ตรวจสอบเมนูต้อนรับ

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import builtins
 import importlib
+import pandas as pd
 
 
 def test_welcome_menu_exit(monkeypatch, capsys):
@@ -10,3 +11,25 @@ def test_welcome_menu_exit(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "NICEGOLD Assistant" in output
     assert "ออกจากระบบ" in output
+
+
+def test_welcome_manual_backtest(monkeypatch, capsys, tmp_path):
+    inputs = iter(['4'])
+
+    monkeypatch.setattr(builtins, "input", lambda prompt='': next(inputs))
+
+    main = importlib.import_module('main')
+    monkeypatch.setattr(main, "TRADE_DIR", str(tmp_path))
+    monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
+        'date': [25670101]*20,
+        'timestamp': ['00:00:00']*20,
+        'open': [1]*20,
+        'high': [1]*20,
+        'low': [1]*20,
+        'close': [1]*20
+    }))
+    monkeypatch.setattr(main, "run_walkforward_backtest", lambda df, features, label: pd.DataFrame({'time': [pd.Timestamp('2024-01-01')], 'pnl': [1]}))
+    main.welcome()
+    output = capsys.readouterr().out
+    assert "Backtest จาก Signal" in output
+    assert "บันทึกผล Backtest" in output


### PR DESCRIPTION
## Notes
- ปรับเมนู backtest จาก signal ให้สร้างชุดฟีเจอร์และเรียก `run_walkforward_backtest`
- เพิ่ม unit test สำหรับเส้นทางเมนูใหม่นี้
- อัปเดต AGENTS.md และ changelog.md ตามแนวทาง

## Testing
- `pytest -q`