### PR TITLE
Add parallel walk-forward backtest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,6 @@
 - ปรับเมนู Backtest จาก Signal ให้สร้างฟีเจอร์และใช้ `run_walkforward_backtest`
 ### 2025-05-31
 - เพิ่มฟังก์ชัน `run_fast_wfv` และแก้เมนู Backtest จาก Signal ให้ใช้ฟังก์ชันใหม่นี้
+### 2025-06-01
+- เพิ่มฟังก์ชัน `run_parallel_wfv` ใช้ multiprocessing สำหรับ walk-forward และปรับ unit test
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 ## 2025-05-31
 - เพิ่มฟังก์ชัน `run_fast_wfv` และปรับเมนู Backtest จาก Signal ให้บันทึกผลโดยฟังก์ชันนี้
 
+## 2025-06-01
+- เพิ่ม `run_parallel_wfv` ใน `main.py` เพื่อรัน Walk-Forward แบบขนาน
+- ปรับเมนู Backtest จาก Signal ให้ใช้ฟังก์ชันใหม่
+- อัพเดต unit test สำหรับ CLI และ core
+
 ## 2025-05-30
 - เมนู Backtest จาก Signal ใช้ walk-forward backtest และบันทึกไฟล์ผลลัพธ์
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,11 +28,11 @@ def test_welcome_manual_backtest(monkeypatch, capsys, tmp_path):
         'low': [1]*20,
         'close': [1]*20
     }))
-    def fake_run_fast_wfv(df, features, label):
+    def fake_run_parallel_wfv(df, features, label):
         print("📦 Saved trades to: test.csv")
         return pd.DataFrame({"time": [pd.Timestamp("2024-01-01")], "pnl": [1]})
 
-    monkeypatch.setattr(main, "run_fast_wfv", fake_run_fast_wfv)
+    monkeypatch.setattr(main, "run_parallel_wfv", fake_run_parallel_wfv)
     main.welcome()
     output = capsys.readouterr().out
     assert "Backtest จาก Signal" in output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -86,3 +86,13 @@ def test_session_performance():
     trades = wfv.run_walkforward_backtest(df, ['feat1', 'feat2'], 'label', n_folds=2)
     perf = wfv.session_performance(trades)
     assert 'sum' in perf.columns
+
+
+def test_run_parallel_wfv(tmp_path, monkeypatch):
+    import importlib
+    main = importlib.import_module('main')
+    df = sample_wfv_df()
+    monkeypatch.setattr(main, 'TRADE_DIR', str(tmp_path))
+    monkeypatch.setattr(main, 'maximize_ram', lambda: None)
+    trades = main.run_parallel_wfv(df, ['Open', 'feat1', 'feat2'], 'label', n_folds=2)
+    assert isinstance(trades, pd.DataFrame)


### PR DESCRIPTION
## Notes
- เพิ่มฟังก์ชัน `run_parallel_wfv` ใน `main.py` ใช้ multiprocessing ทำ Walk-Forward backtest
- ปรับเมนู Backtest จาก Signal ให้เรียกใช้ฟังก์ชันนี้แทน
- อัพเดตชุดทดสอบ CLI และ core ให้รองรับฟังก์ชันใหม่
- บันทึกการเปลี่ยนแปลงใน `AGENTS.md` และ `changelog.md`
