### PR TITLE
Implement QA summary utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,4 +73,8 @@
 ### 2025-06-06
 - ปรับเมนู Backtest จาก Signal ให้เรียก `generate_signals` และ `run_backtest`
 
+### 2025-06-07
+- เพิ่มฟังก์ชัน `print_qa_summary`, `export_chatgpt_ready_logs`, `create_summary_dict`
+- อัพเดต unit test สำหรับฟังก์ชันใหม่
+
 

--- a/changelog.md
+++ b/changelog.md
@@ -46,3 +46,7 @@
 ## 2025-06-06
 - เมนู Backtest จาก Signal ใช้ `generate_signals` และ `run_backtest` โดยตรง
 
+## 2025-06-07
+- เพิ่ม `print_qa_summary`, `export_chatgpt_ready_logs`, `create_summary_dict`
+- เพิ่ม unit test สำหรับฟังก์ชันเหล่านี้
+

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -2,5 +2,11 @@ from .entry import generate_signals
 from .risk import calc_lot
 from .exit import should_exit
 from .backtester import run_backtest
-from .utils import summarize_results, run_auto_wfv
+from .utils import (
+    summarize_results,
+    run_auto_wfv,
+    print_qa_summary,
+    export_chatgpt_ready_logs,
+    create_summary_dict,
+)
 from .wfv import run_walkforward_backtest, session_performance, streak_summary

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,3 +116,23 @@ def test_run_parallel_wfv_lowercase(tmp_path, monkeypatch):
     monkeypatch.setattr(main, 'maximize_ram', lambda: None)
     trades = main.run_parallel_wfv(df, ['Open', 'feat1', 'feat2'], 'label', n_folds=2)
     assert isinstance(trades, pd.DataFrame)
+
+
+def test_print_qa_summary_and_export(tmp_path):
+    from nicegold_v5.utils import print_qa_summary, export_chatgpt_ready_logs, create_summary_dict
+    trades = pd.DataFrame({
+        'pnl': [1.0, -0.5],
+        'lot': [0.1, 0.1],
+        'commission': [0.02, 0.02]
+    })
+    equity = pd.DataFrame({
+        'timestamp': pd.date_range('2024-01-01', periods=2, freq='D'),
+        'equity': [100, 100.5]
+    })
+
+    metrics = print_qa_summary(trades, equity)
+    assert metrics['total_trades'] == 2
+    summary = create_summary_dict(trades, equity, file_name="test.csv")
+    export_chatgpt_ready_logs(trades, equity, summary, outdir=str(tmp_path))
+    files = list(tmp_path.iterdir())
+    assert len(files) == 3


### PR DESCRIPTION
## Notes
- Added functions to generate QA summary reports and export logs.
- Updated unit tests and documentation entries.

## Summary
- Implemented `print_qa_summary`, `export_chatgpt_ready_logs`, and `create_summary_dict` in `utils.py`.
- Re-exported new utilities in package `__init__.py`.
- Added a unit test exercising summary and export features.
- Documented new functions in `AGENTS.md` and `changelog.md`.

## Testing
- `pytest -q`