### PR TITLE
Implement new manual backtest export flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,4 +77,7 @@
 - เพิ่มฟังก์ชัน `print_qa_summary`, `export_chatgpt_ready_logs`, `create_summary_dict`
 - อัพเดต unit test สำหรับฟังก์ชันใหม่
 
+### 2025-06-08
+- เมนู Backtest จาก Signal แสดง QA summary และ export CSV logs แบบละเอียด
+
 

--- a/changelog.md
+++ b/changelog.md
@@ -50,3 +50,6 @@
 - เพิ่ม `print_qa_summary`, `export_chatgpt_ready_logs`, `create_summary_dict`
 - เพิ่ม unit test สำหรับฟังก์ชันเหล่านี้
 
+## 2025-06-08
+- เมนู Backtest จาก Signal แสดง QA summary และ export ไฟล์ CSV log
+

--- a/main.py
+++ b/main.py
@@ -203,12 +203,36 @@ def welcome():
         df = load_csv_safe(M1_PATH)
 
         from nicegold_v5.entry import generate_signals
+        from nicegold_v5.backtester import run_backtest
+        from nicegold_v5.utils import (
+            print_qa_summary,
+            create_summary_dict,
+            export_chatgpt_ready_logs,
+        )
+        import time
+
         df = generate_signals(df)
 
-        from nicegold_v5.backtester import run_backtest
+        start_time = pd.to_datetime(df["timestamp"].iloc[0])
+        end_time = pd.to_datetime(df["timestamp"].iloc[-1])
+        start = time.time()
         trades, equity = run_backtest(df)
+        end = time.time()
 
-        print(f"✅ เสร็จแล้ว: Trades = {len(trades)} | Profit = {trades['pnl'].sum():.2f}")
+        # 1️⃣ แสดงสรุป QA ใน Console
+        metrics = print_qa_summary(trades, equity)
+
+        # 2️⃣ สร้าง Summary Dict สำหรับ export
+        summary_dict = create_summary_dict(
+            trades, equity,
+            file_name="XAUUSD_M1.csv",
+            start_time=start_time,
+            end_time=end_time,
+            duration_sec=end - start
+        )
+
+        # 3️⃣ Export CSV Logs (ChatGPT/Excel-ready)
+        export_chatgpt_ready_logs(trades, equity, summary_dict, outdir=TRADE_DIR)
 
     elif choice == 5:
         show_progress_bar("👋 กำลังออกจากระบบ", steps=2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,11 +31,16 @@ def test_welcome_manual_backtest(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df: df.assign(entry_signal='buy'))
 
     def fake_run_backtest(df):
-        print("✅ เสร็จแล้ว: Trades = 1 | Profit = 1.00")
-        return pd.DataFrame({'pnl': [1]}), pd.DataFrame()
+        return (
+            pd.DataFrame({'pnl': [1]}),
+            pd.DataFrame({'timestamp': [pd.Timestamp('2024-01-01')], 'equity': [100]})
+        )
 
     monkeypatch.setattr('nicegold_v5.backtester.run_backtest', fake_run_backtest)
+    monkeypatch.setattr('nicegold_v5.utils.print_qa_summary', lambda *args, **kwargs: {})
+    monkeypatch.setattr('nicegold_v5.utils.create_summary_dict', lambda *args, **kwargs: {})
+    monkeypatch.setattr('nicegold_v5.utils.export_chatgpt_ready_logs', lambda *args, **kwargs: print('Export Completed'))
     main.welcome()
     output = capsys.readouterr().out
     assert "Backtest จาก Signal" in output
-    assert "เสร็จแล้ว" in output
+    assert "Export Completed" in output


### PR DESCRIPTION
## Summary
- extend menu option 4 to print QA summary and export logs
- update CLI tests for new export behaviour
- document patch details in AGENTS and changelog

## Testing
- `pytest -q`