### PR TITLE
Implement QA logging with session metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,4 +81,8 @@
 ### 2025-06-08
 - เมนู Backtest จาก Signal แสดง QA summary และ export CSV logs แบบละเอียด
 
+### 2025-06-09
+- เพิ่มฟังก์ชัน `build_trade_log` บันทึกรายละเอียด R-multiple และ session
+- อัพเดต `run_walkforward_backtest` ให้ใช้ฟังก์ชันนี้
+
 

--- a/changelog.md
+++ b/changelog.md
@@ -53,3 +53,7 @@
 ## 2025-06-08
 - เมนู Backtest จาก Signal แสดง QA summary และ export ไฟล์ CSV log
 
+## 2025-06-09
+- เพิ่ม `build_trade_log` เพื่อบันทึกรายละเอียดไม้เทรด (R-multiple, session)
+- อัพเดต `run_walkforward_backtest` ใช้งานฟังก์ชันนี้
+

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -9,4 +9,9 @@ from .utils import (
     export_chatgpt_ready_logs,
     create_summary_dict,
 )
-from .wfv import run_walkforward_backtest, session_performance, streak_summary
+from .wfv import (
+    run_walkforward_backtest,
+    session_performance,
+    streak_summary,
+    build_trade_log,
+)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,6 +90,8 @@ def test_run_walkforward_backtest():
     )
     assert isinstance(trades, pd.DataFrame)
     assert not trades.empty
+    assert 'r_multiple' in trades.columns
+    assert 'session' in trades.columns
 
 
 def test_session_performance():


### PR DESCRIPTION
## Summary
- add `build_trade_log` helper to compute R-multiple and session info
- use new helper within `run_walkforward_backtest`
- re-export new helper in `__init__`
- update unit tests for new fields
- document updates in AGENTS.md and changelog

## Testing
- `pytest -q`