### PR TITLE
Implement ATR-based SL and breakeven logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,3 +89,7 @@
 - ปรับเมนู Backtest จาก Signal ให้เรียก Patch K+L+M
 
 
+### 2025-06-11
+- เพิ่มตรรกะ SL ตาม ATR, ระบบ Breakeven และ TP1/TP2 ใน backtester
+- เพิ่ม unit test ตรวจสอบกรณีโดน SL
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+## 2025-06-11
+- ปรับ backtester ให้บันทึกเวลาแบบ datetime และเพิ่มระบบ SL, Breakeven, TP1/TP2
+- เพิ่มการทดสอบ backtest_hit_sl_expected
+
 
 ## 2025-05-31
 - เพิ่มฟังก์ชัน `run_fast_wfv` และปรับเมนู Backtest จาก Signal ให้บันทึกผลโดยฟังก์ชันนี้

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -15,20 +15,74 @@ def run_backtest(df: pd.DataFrame):
     start = time.time()
 
     for i, row in tqdm(df.iterrows(), total=len(df), desc="⏱️ Running Backtest", unit="rows"):
-        ts = row["timestamp"]
+        ts = pd.to_datetime(row["timestamp"])
         price = row["close"]
         equity.append({"timestamp": ts, "equity": capital})
 
         if open_trade:
-            exit_now, reason = should_exit(open_trade, row)
-            if exit_now:
-                pnl = (price - open_trade["entry"] if open_trade["type"] == "buy"
-                       else open_trade["entry"] - price) * open_trade["lot"] * 10
-                capital += pnl
-                open_trade["exit"] = ts
-                open_trade["pnl"] = pnl
-                trades.append(open_trade)
-                open_trade = None
+            gain = price - open_trade["entry"] if open_trade["type"] == "buy" else open_trade["entry"] - price
+            sl_dist = row.get("atr", 1.0) * 1.5
+            tp1 = sl_dist * 1.5
+            tp2 = sl_dist * 2.5
+
+            if not open_trade.get("tp1_hit") and gain >= tp1:
+                partial_lot = open_trade["lot"] * 0.5
+                partial_pnl = tp1 * open_trade["lot"] * 10 * 0.5
+                capital += partial_pnl
+                trades.append({
+                    "entry_time": open_trade["entry_time"],
+                    "exit_time": ts,
+                    "entry": open_trade["entry"],
+                    "exit": price,
+                    "type": open_trade["type"],
+                    "lot": partial_lot,
+                    "pnl": partial_pnl,
+                    "exit_reason": "TP1",
+                    "session": "Asia" if ts.hour < 8 else "London" if ts.hour < 16 else "NY",
+                    "duration_min": (ts - open_trade["entry_time"]).total_seconds() / 60,
+                })
+                open_trade["tp1_hit"] = True
+                open_trade["lot"] = open_trade["lot"] * 0.5
+
+            elif open_trade.get("tp1_hit"):
+                exit_now, reason = should_exit(open_trade, row)
+                if exit_now:
+                    pnl = (price - open_trade["entry"] if open_trade["type"] == "buy"
+                           else open_trade["entry"] - price) * open_trade["lot"] * 10
+                    capital += pnl
+                    trades.append({
+                        "entry_time": open_trade["entry_time"],
+                        "exit_time": ts,
+                        "entry": open_trade["entry"],
+                        "exit": price,
+                        "type": open_trade["type"],
+                        "lot": open_trade["lot"],
+                        "pnl": pnl,
+                        "exit_reason": reason or "TP2",
+                        "session": "Asia" if ts.hour < 8 else "London" if ts.hour < 16 else "NY",
+                        "duration_min": (ts - open_trade["entry_time"]).total_seconds() / 60,
+                    })
+                    open_trade = None
+
+            else:
+                exit_now, reason = should_exit(open_trade, row)
+                if exit_now:
+                    pnl = (price - open_trade["entry"] if open_trade["type"] == "buy"
+                           else open_trade["entry"] - price) * open_trade["lot"] * 10
+                    capital += pnl
+                    trades.append({
+                        "entry_time": open_trade["entry_time"],
+                        "exit_time": ts,
+                        "entry": open_trade["entry"],
+                        "exit": price,
+                        "type": open_trade["type"],
+                        "lot": open_trade["lot"],
+                        "pnl": pnl,
+                        "exit_reason": reason or "TP",
+                        "session": "Asia" if ts.hour < 8 else "London" if ts.hour < 16 else "NY",
+                        "duration_min": (ts - open_trade["entry_time"]).total_seconds() / 60,
+                    })
+                    open_trade = None
 
         if not open_trade and row.get("entry_signal") in ["buy", "sell"]:
             lot = calc_lot(capital)

--- a/nicegold_v5/exit.py
+++ b/nicegold_v5/exit.py
@@ -1,7 +1,38 @@
+import logging
+
+
 def should_exit(trade, row):
-    gain = (row["close"] - trade["entry"] if trade["type"] == "buy" else trade["entry"] - row["close"])
+    price_now = row["close"]
+    entry = trade["entry"]
+    direction = trade["type"]
+    gain = price_now - entry if direction == "buy" else entry - price_now
+
+    atr = row.get("atr", 1.0)
+    sl_threshold = atr * 1.5
+    be_trigger = sl_threshold * 1.2
+
+    if gain < -sl_threshold and not trade.get("breakeven"):
+        logging.info(f"[Patch] SL Hit: {direction.upper()} @ {price_now:.2f} (Loss: {gain:.2f})")
+        return True, "SL"
+
+    if gain >= be_trigger and not trade.get("breakeven"):
+        trade["breakeven"] = True
+        trade["breakeven_price"] = entry
+        trade["break_even_time"] = row["timestamp"]
+        logging.info(
+            f"[Patch] BE Move Triggered at {row['timestamp']} | SL moved to {entry:.2f}"
+        )
+
+    if trade.get("breakeven") and (
+        (direction == "buy" and price_now <= entry) or
+        (direction == "sell" and price_now >= entry)
+    ):
+        logging.info(f"[Patch] BE Stop-Loss Hit @ {price_now:.2f}")
+        return True, "BE_SL"
+
     if gain > 0 and row.get("gain_z", 0) < -0.5:
         return True, "gain_z drop"
     if gain > 0 and row.get("atr", 1.0) < row.get("atr_ma", 1.0):
         return True, "atr fading"
+
     return False, None

--- a/tests/test_gold_ai.py
+++ b/tests/test_gold_ai.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from nicegold_v5.backtester import run_backtest
+
+
+def test_backtest_hit_sl_expected():
+    """ทดสอบว่าไม้โดน SL และออกด้วยเหตุผล SL"""
+    df = pd.DataFrame({
+        "timestamp": pd.date_range(start="2025-01-01", periods=5, freq="T"),
+        "open": [100, 100.5, 100.8, 101.0, 101.2],
+        "high": [100, 100.6, 100.9, 101.1, 101.3],
+        "low": [99.5, 99.8, 100.0, 100.2, 100.4],
+        "close": [100.0, 99.0, 98.9, 99.1, 99.0],
+        "entry_signal": ["buy", None, None, None, None],
+        "atr": [0.5] * 5,
+        "atr_ma": [0.6] * 5,
+        "gain_z": [0.0] * 5,
+    })
+
+    trades, equity = run_backtest(df)
+    assert not trades.empty
+    assert any(trades["exit_reason"] == "SL")
+    assert (trades["pnl"] < 0).any()


### PR DESCRIPTION
## Summary
- enhance backtester to support partial TP1, TP2, and breakeven logic
- update exit rules with ATR-based stop loss and breakeven
- record timestamps as full datetime
- add unit test for SL scenario
- update agents and changelog

## Testing
- `pytest -q`