### PR TITLE
ปรับลด warning ใน unit test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,6 @@
 - เพิ่มตรรกะ SL ตาม ATR, ระบบ Breakeven และ TP1/TP2 ใน backtester
 - เพิ่ม unit test ตรวจสอบกรณีโดน SL
 
+### 2025-06-12
+- แก้คำเตือน pandas เรื่องตัวเลือกความถี่และปรับ Pool ให้ใช้ spawn
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2025-06-12
+- แก้ไขคำเตือน pandas ในชุดทดสอบและปรับ `run_parallel_wfv` ให้ใช้ `spawn`
+
 ## 2025-06-11
 - ปรับ backtester ให้บันทึกเวลาแบบ datetime และเพิ่มระบบ SL, Breakeven, TP1/TP2
 - เพิ่มการทดสอบ backtest_hit_sl_expected

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ from nicegold_v5.wfv import (
 # Keep backward-compatible name
 run_walkforward_backtest = raw_run
 
-from multiprocessing import Pool, cpu_count
+from multiprocessing import cpu_count, get_context
 from sklearn.model_selection import TimeSeriesSplit
 import numpy as np
 from nicegold_v5.utils import run_auto_wfv
@@ -69,7 +69,7 @@ def run_parallel_wfv(df: pd.DataFrame, features: list, label_col: str, n_folds: 
     tscv = TimeSeriesSplit(n_splits=n_folds)
     args_list = [(df.iloc[test_idx], features, label_col, i) for i, (_, test_idx) in enumerate(tscv.split(df))]
 
-    with Pool(processes=min(cpu_count(), n_folds)) as pool:
+    with get_context("spawn").Pool(processes=min(cpu_count(), n_folds)) as pool:
         trades_list = list(tqdm(pool.imap(_run_fold, args_list), total=n_folds))
 
     all_df = pd.concat(trades_list, ignore_index=True)

--- a/nicegold_v5/wfv.py
+++ b/nicegold_v5/wfv.py
@@ -112,7 +112,7 @@ def run_walkforward_backtest(df, features, label_col, side='buy', n_folds=3, per
     for fold, (train_idx, test_idx) in enumerate(folds.split(df)):
         df_train = df.iloc[train_idx].copy()
         df_test = df.iloc[test_idx].copy()
-        X_train = df_train[features]
+        X_train = df_train[features].astype(float)
         y_train = df_train[label_col]
 
         model = Pipeline([
@@ -121,7 +121,7 @@ def run_walkforward_backtest(df, features, label_col, side='buy', n_folds=3, per
         ])
         model.fit(X_train, y_train)
 
-        df_test['entry_prob'] = model.predict_proba(df_test[features])[:, 1]
+        df_test['entry_prob'] = model.predict_proba(df_test[features].astype(float))[:, 1]
         prob_thresh = np.percentile(df_test['entry_prob'], percentile_threshold)
 
         equity = INITIAL_CAPITAL

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,7 +21,7 @@ def sample_df():
 
 
 def sample_wfv_df():
-    ts = pd.date_range('2024-01-01', periods=40, freq='H')
+    ts = pd.date_range('2024-01-01', periods=40, freq='h')
     data = {
         'Open': pd.Series(range(40)) + 100,
         'feat1': pd.Series(range(40)) * 0.1,

--- a/tests/test_gold_ai.py
+++ b/tests/test_gold_ai.py
@@ -5,7 +5,7 @@ from nicegold_v5.backtester import run_backtest
 def test_backtest_hit_sl_expected():
     """ทดสอบว่าไม้โดน SL และออกด้วยเหตุผล SL"""
     df = pd.DataFrame({
-        "timestamp": pd.date_range(start="2025-01-01", periods=5, freq="T"),
+        "timestamp": pd.date_range(start="2025-01-01", periods=5, freq="min"),
         "open": [100, 100.5, 100.8, 101.0, 101.2],
         "high": [100, 100.6, 100.9, 101.1, 101.3],
         "low": [99.5, 99.8, 100.0, 100.2, 100.4],


### PR DESCRIPTION
## Notes
- แก้การแจ้งเตือนจาก pandas โดยใช้โค้ดความถี่ตัวพิมพ์เล็ก
- ปรับ `run_parallel_wfv` ให้ใช้ `spawn` เพื่อหลีกเลี่ยง DeprecationWarning
- แปลงข้อมูลเป็น `float` ใน `run_walkforward_backtest` ลดปัญหา `invalid value` ใน `StandardScaler`

## Summary
- ปรับ Pool เป็น `get_context("spawn")`
- ปรับความถี่ในชุดทดสอบ (`h`, `min`)
- แปลงชนิดข้อมูลเป็น `float` ใน `wfv.run_walkforward_backtest`
- อัปเดต `AGENTS.md` และ `changelog.md`

## Testing
- `pytest -q`