### PR TITLE
เพิ่มค่าคอม สเปรด และ slippage ใน backtest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,6 @@
 
 ### 2025-06-16
 - รวมฟังก์ชันจาก `m.ainmain.py` เข้ากับ `main.py` เพื่อใช้งาน Advanced Risk Management
+### 2025-06-17
+- เพิ่มต้นทุนค่าคอมมิชัน สเปรด และ Slippage ใน backtester ทุกจุดปิดไม้
+- ปรับ kill_switch ให้รอเทรดครบขั้นต่ำก่อนตรวจ Drawdown และแก้ NaT ใน create_summary_dict

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 ## 2025-06-16
 - รวมฟังก์ชันจาก `m.ainmain.py` เข้ากับ `main.py`
+## 2025-06-17
+- เพิ่มต้นทุนค่าคอมมิชัน สเปรด และ Slippage ให้ทุก trade ใน backtester
+- ปรับ kill_switch รอให้มีเทรดมากกว่า 100 ไม้ก่อนเริ่มตรวจ Drawdown
+- ป้องกัน NaTType crash ใน `create_summary_dict`
 ## 2025-06-15
 - เพิ่มระบบ Kill Switch, Recovery Lot และ Dynamic SL/TP ใน backtester
 ## 2025-06-14

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from datetime import datetime
+import random
 from nicegold_v5.risk import (
     calc_lot,
     calc_lot_risk,
@@ -44,7 +45,10 @@ def run_backtest(df: pd.DataFrame):
             if not open_trade.get("tp1_hit") and gain >= tp1:
                 partial_lot = open_trade["lot"] * 0.5
                 partial_pnl = tp1 * open_trade["lot"] * 10 * 0.5
-                capital += partial_pnl
+                commission = partial_lot * 2
+                spread_cost = partial_lot * 0.2
+                slippage_cost = abs(random.uniform(-0.3, 0.3)) * partial_lot
+                capital += partial_pnl - commission - spread_cost - slippage_cost
                 trades.append({
                     "entry_time": open_trade["entry_time"],
                     "exit_time": ts,
@@ -52,7 +56,10 @@ def run_backtest(df: pd.DataFrame):
                     "exit": price,
                     "type": open_trade["type"],
                     "lot": partial_lot,
-                    "pnl": partial_pnl,
+                    "pnl": partial_pnl - commission - spread_cost - slippage_cost,
+                    "commission": commission,
+                    "spread_cost": spread_cost,
+                    "slippage_cost": slippage_cost,
                     "exit_reason": "TP1",
                     "session": session,
                     "duration_min": (ts - open_trade["entry_time"]).total_seconds() / 60,
@@ -64,7 +71,10 @@ def run_backtest(df: pd.DataFrame):
                 exit_now, reason = should_exit(open_trade, row)
                 if exit_now or (direction == "buy" and gain >= tp2) or (direction == "sell" and gain >= tp2):
                     pnl = (price - open_trade["entry"] if direction == "buy" else open_trade["entry"] - price) * open_trade["lot"] * 10
-                    capital += pnl
+                    commission = open_trade["lot"] * 2
+                    spread_cost = open_trade["lot"] * 0.2
+                    slippage_cost = abs(random.uniform(-0.3, 0.3)) * open_trade["lot"]
+                    capital += pnl - commission - spread_cost - slippage_cost
                     trades.append({
                         "entry_time": open_trade["entry_time"],
                         "exit_time": ts,
@@ -72,7 +82,10 @@ def run_backtest(df: pd.DataFrame):
                         "exit": price,
                         "type": direction,
                         "lot": open_trade["lot"],
-                        "pnl": pnl,
+                        "pnl": pnl - commission - spread_cost - slippage_cost,
+                        "commission": commission,
+                        "spread_cost": spread_cost,
+                        "slippage_cost": slippage_cost,
                         "exit_reason": reason or "TP2",
                         "session": session,
                         "duration_min": (ts - open_trade["entry_time"]).total_seconds() / 60,
@@ -87,7 +100,10 @@ def run_backtest(df: pd.DataFrame):
                 exit_now, reason = should_exit(open_trade, row)
                 if exit_now:
                     pnl = (price - open_trade["entry"] if direction == "buy" else open_trade["entry"] - price) * open_trade["lot"] * 10
-                    capital += pnl
+                    commission = open_trade["lot"] * 2
+                    spread_cost = open_trade["lot"] * 0.2
+                    slippage_cost = abs(random.uniform(-0.3, 0.3)) * open_trade["lot"]
+                    capital += pnl - commission - spread_cost - slippage_cost
                     trades.append({
                         "entry_time": open_trade["entry_time"],
                         "exit_time": ts,
@@ -95,7 +111,10 @@ def run_backtest(df: pd.DataFrame):
                         "exit": price,
                         "type": direction,
                         "lot": open_trade["lot"],
-                        "pnl": pnl,
+                        "pnl": pnl - commission - spread_cost - slippage_cost,
+                        "commission": commission,
+                        "spread_cost": spread_cost,
+                        "slippage_cost": slippage_cost,
                         "exit_reason": reason or "TP",
                         "session": session,
                         "duration_min": (ts - open_trade["entry_time"]).total_seconds() / 60,

--- a/nicegold_v5/risk.py
+++ b/nicegold_v5/risk.py
@@ -8,12 +8,13 @@ def calc_lot(capital: float, risk_pct: float = 1.5, sl_pips: float = 100) -> flo
 # --- Patch C: Advanced Risk Management ---
 
 KILL_SWITCH_DD = 25  # % drawdown limit
+MIN_TRADES_BEFORE_KILL = 100  # ต้องมีเทรดมากกว่า 100 ไม้ก่อนจึงเริ่มตรวจ DD
 
 
 def kill_switch(equity_curve: list[float]) -> bool:
-    """Return True if drawdown exceeds threshold."""
-    if not equity_curve:
-        return False
+    """Return True if drawdown exceeds threshold (หลังจากเทรดครบ MIN_TRADES_BEFORE_KILL)"""
+    if not equity_curve or len(equity_curve) < MIN_TRADES_BEFORE_KILL:
+        return False  # ยังไม่ตรวจ drawdown
     peak = equity_curve[0]
     for eq in equity_curve:
         drawdown = (peak - eq) / peak * 100

--- a/nicegold_v5/utils.py
+++ b/nicegold_v5/utils.py
@@ -109,10 +109,26 @@ def export_chatgpt_ready_logs(trades: pd.DataFrame, equity: pd.DataFrame, summar
     print(f"   └ summary_metrics → {summary_path}")
 
 
-def create_summary_dict(trades: pd.DataFrame, equity: pd.DataFrame, file_name: str = "", start_time: datetime | None = None, end_time: datetime | None = None, duration_sec: float | None = None) -> dict:
+def create_summary_dict(
+    trades: pd.DataFrame,
+    equity: pd.DataFrame,
+    file_name: str = "",
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    duration_sec: float | None = None,
+) -> dict:
     """Create a summary dictionary for export_chatgpt_ready_logs."""
+
     start_eq = equity.iloc[0]["equity"] if not equity.empty else 0
     end_eq = equity.iloc[-1]["equity"] if not equity.empty else 0
+
+    safe_start_time = (
+        start_time.strftime("%Y-%m-%d %H:%M:%S") if pd.notnull(start_time) else ""
+    )
+    safe_end_time = (
+        end_time.strftime("%Y-%m-%d %H:%M:%S") if pd.notnull(end_time) else ""
+    )
+
     return {
         "file_name": file_name,
         "total_trades": len(trades),
@@ -123,17 +139,17 @@ def create_summary_dict(trades: pd.DataFrame, equity: pd.DataFrame, file_name: s
         "avg_pnl": round(trades["pnl"].mean(), 4) if not trades.empty else 0,
         "total_lot": round(trades.get("lot", pd.Series(dtype=float)).sum(), 2),
         "commission_paid": round(trades.get("commission", pd.Series(dtype=float)).sum(), 2),
-        "spread_impact": round(trades.get("spread", pd.Series(dtype=float)).sum(), 2),
-        "slippage_impact": round(trades.get("slippage", pd.Series(dtype=float)).sum(), 2),
+        "spread_impact": round(trades.get("spread_cost", pd.Series(dtype=float)).sum(), 2),
+        "slippage_impact": round(trades.get("slippage_cost", pd.Series(dtype=float)).sum(), 2),
         "total_cost_deducted": round(
             trades.get("commission", pd.Series(dtype=float)).sum()
-            + trades.get("spread", pd.Series(dtype=float)).sum()
-            + trades.get("slippage", pd.Series(dtype=float)).sum(),
+            + trades.get("spread_cost", pd.Series(dtype=float)).sum()
+            + trades.get("slippage_cost", pd.Series(dtype=float)).sum(),
             2,
         ),
         "duration_sec": round(duration_sec, 2) if duration_sec is not None else None,
-        "start_time": start_time.strftime("%Y-%m-%d %H:%M:%S") if start_time else "",
-        "end_time": end_time.strftime("%Y-%m-%d %H:%M:%S") if end_time else "",
+        "start_time": safe_start_time,
+        "end_time": safe_end_time,
     }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -64,8 +64,13 @@ def test_calc_lot():
 
 
 def test_kill_switch_trigger():
-    curve = [100, 95, 70]
+    curve = [100] * 100 + [95, 70]
     assert kill_switch(curve)
+
+
+def test_kill_switch_waits_min_trades():
+    curve = [100, 95, 70]
+    assert not kill_switch(curve)
 
 
 def test_recovery_lot():
@@ -148,7 +153,9 @@ def test_print_qa_summary_and_export(tmp_path):
     trades = pd.DataFrame({
         'pnl': [1.0, -0.5],
         'lot': [0.1, 0.1],
-        'commission': [0.02, 0.02]
+        'commission': [0.02, 0.02],
+        'spread_cost': [0.01, 0.01],
+        'slippage_cost': [0.0, 0.0]
     })
     equity = pd.DataFrame({
         'timestamp': pd.date_range('2024-01-01', periods=2, freq='D'),


### PR DESCRIPTION
## Notes
- ปรับ backtester ให้หักค่าคอมมิชัน สเปรด และ slippage ที่ทุกจุดปิดไม้
- kill_switch รอตรวจ drawdown หลังมีเทรดเกิน 100 ไม้
- create_summary_dict รองรับคอลัมน์ใหม่และป้องกัน NaT
- เพิ่ม unit test สำหรับ kill_switch และปรับข้อมูลค่าสเปรด/สลิปเพจ
- อัพเดต AGENTS.md และ changelog.md ตามแพทช์ล่าสุด

## Testing
- `pytest -q`