### PR TITLE
Implement early profit lock exit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,6 @@
 - ปรับปรุง `generate_signals` เพิ่มระบบ fallback และบันทึกเหตุผลการบล็อกอย่างละเอียด (Patch D.9)
 - ปรับ `should_exit` ด้วย Momentum exit logic ใหม่ (Patch D.10)
 
+### 2025-06-30
+- ปรับปรุง `should_exit` เพิ่ม Early Profit Lock และข้อความ debug (Patch D.12)
+

--- a/changelog.md
+++ b/changelog.md
@@ -123,3 +123,6 @@
 ## 2025-06-29
 - ปรับปรุง `generate_signals` ด้วยระบบ fallback และบันทึกเหตุผลการบล็อก (Patch D.9)
 - ปรับ `should_exit` เพิ่ม Momentum exit logic (Patch D.10)
+
+## 2025-06-30
+- เพิ่ม Early Profit Lock ใน `should_exit` และบันทึก debug ถือครองสั้น (Patch D.12)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -196,6 +196,24 @@ def test_should_exit():
     exit_now, reason = should_exit(trade, row)
     assert exit_now
 
+def test_early_profit_lock():
+    trade = {
+        'entry': 100,
+        'type': 'buy',
+        'lot': 0.1,
+        'entry_time': pd.Timestamp('2025-01-01 00:00:00')
+    }
+    row = {
+        'close': 100.6,
+        'gain_z': -0.1,
+        'atr': 1.0,
+        'atr_ma': 1.0,
+        'timestamp': pd.Timestamp('2025-01-01 00:20:00')
+    }
+    exit_now, reason = should_exit(trade, row)
+    assert exit_now
+    assert reason == 'early_profit_lock'
+
 
 def test_backtester_run():
     df = sample_df()


### PR DESCRIPTION
## Notes
- Update exit logic with early profit lock and debug messages
- Add unit test for early profit lock
- Document patch D.12 in AGENTS and changelog

## Summary
- finalize `should_exit` with Patch D.12 behavior
- include new test `test_early_profit_lock`

## Testing
- `pytest -q`