### PR TITLE
Patch v6.0-6.1 updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,4 +175,8 @@
 
 ### 2025-07-11
 - แก้คำเตือน pandas เรื่องการใช้ inplace บน Series ใน `nicegold_v5/entry.py`
+### 2025-07-12
+- ปรับค่าคอมมิชันเป็น 0.07 USD ต่อ 0.01 lot ใน backtester
+- ผ่อนปรนเงื่อนไข momentum, ATR และ volume ใน generate_signals (Patch v6.1)
+- ปรับ session_label ให้ระบุเฉพาะช่วง NY เท่านั้น
 

--- a/changelog.md
+++ b/changelog.md
@@ -151,4 +151,7 @@
 - เพิ่ม Patch Perf-D เพิ่ม log เวลาในฟังก์ชันหลัก
 ## 2025-07-11
 - แก้คำเตือน pandas ใน `nicegold_v5/entry.py` ที่ใช้ fillna inplace บน Series
+## 2025-07-12
+- ปรับค่าคอมมิชันตามจริงและลด threshold momentum/ATR/volume
+- กำหนด session_label เฉพาะช่วง NY เท่านั้น
 

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -24,6 +24,7 @@ def run_backtest(df: pd.DataFrame):
     """Backtest พร้อม Recovery Mode และ Logging เต็มรูปแบบ"""
     logging.info(f"[TIME] run_backtest() start: {time.strftime('%H:%M:%S')}")
     capital = 100.0
+    COMMISSION_PER_001_LOT = 0.07  # [Patch v6.0] ค่าคอมจริง: 0.07 USD ต่อ 0.01 lot
     trades = []
     equity = []
     open_trade = None
@@ -76,7 +77,7 @@ def run_backtest(df: pd.DataFrame):
             if not open_trade.get("tp1_hit") and gain >= tp1:
                 partial_lot = open_trade["lot"] * 0.5
                 partial_pnl = tp1 * open_trade["lot"] * 10 * 0.5
-                commission = partial_lot * 2
+                commission = partial_lot / 0.01 * COMMISSION_PER_001_LOT  # [Patch v6.0]
                 spread_cost = partial_lot * 0.2
                 slippage_cost = abs(random.uniform(-0.3, 0.3)) * partial_lot
                 capital += partial_pnl - commission - spread_cost - slippage_cost
@@ -103,7 +104,7 @@ def run_backtest(df: pd.DataFrame):
                 exit_now, reason = should_exit(open_trade, row)
                 if exit_now or (direction == "buy" and gain >= tp2) or (direction == "sell" and gain >= tp2):
                     pnl = (price - open_trade["entry"] if direction == "buy" else open_trade["entry"] - price) * open_trade["lot"] * 10
-                    commission = open_trade["lot"] * 2
+                    commission = open_trade["lot"] / 0.01 * COMMISSION_PER_001_LOT  # [Patch v6.0]
                     spread_cost = open_trade["lot"] * 0.2
                     slippage_cost = abs(random.uniform(-0.3, 0.3)) * open_trade["lot"]
                     capital += pnl - commission - spread_cost - slippage_cost
@@ -135,7 +136,7 @@ def run_backtest(df: pd.DataFrame):
                 exit_now, reason = should_exit(open_trade, row)
                 if exit_now:
                     pnl = (price - open_trade["entry"] if direction == "buy" else open_trade["entry"] - price) * open_trade["lot"] * 10
-                    commission = open_trade["lot"] * 2
+                    commission = open_trade["lot"] / 0.01 * COMMISSION_PER_001_LOT  # [Patch v6.0]
                     spread_cost = open_trade["lot"] * 0.2
                     slippage_cost = abs(random.uniform(-0.3, 0.3)) * open_trade["lot"]
                     capital += pnl - commission - spread_cost - slippage_cost

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -33,8 +33,6 @@ def generate_signals(df: pd.DataFrame, config: dict | None = None) -> pd.DataFra
 
     # --- Session Tag ---
     df["session_label"] = "None"
-    df.loc[df["timestamp"].dt.hour.between(3, 6), "session_label"] = "Asia"
-    df.loc[df["timestamp"].dt.hour.between(8, 11), "session_label"] = "London"
     df.loc[df["timestamp"].dt.hour.between(13, 17), "session_label"] = "NY"
     session = df["session_label"] != "None"
 
@@ -49,9 +47,9 @@ def generate_signals(df: pd.DataFrame, config: dict | None = None) -> pd.DataFra
     breakout_up = df["close"] > df["ema_50"] + 0.25
     breakout_dn = df["close"] < df["ema_50"] - 0.25
     volatility_ok = df["atr"] > df["atr_ma"] * 0.85
-    momentum_ok = df["gain_z"] > 0.8
-    volume_ok = df["volume"] > df["volume_ma"] * 1.1
-    atr_enough = df["atr"] > 2.2
+    momentum_ok = df["gain_z"] > 0.4  # [Patch v6.1]
+    volume_ok = df["volume"] > df["volume_ma"] * 1.0  # [Patch v6.1]
+    atr_enough = df["atr"] > 1.4  # [Patch v6.1]
 
     # --- Entry Score + TP Ratio ---
     df["entry_score"] = df["gain_z"] * df["atr"] / (df["atr_ma"] + 1e-9)


### PR DESCRIPTION
## Notes
- ปรับคอมมิชัน backtester เป็น 0.07 USD ต่อ 0.01 lot
- ผ่อนปรนตัวกรอง momentum/ATR/volume และตั้ง session เฉพาะ NY

## Summary
- เพิ่ม `COMMISSION_PER_001_LOT` และใช้คำนวณค่าคอมทุกจุดใน `run_backtest`
- ลด threshold entry และกรอง session เฉพาะ NY ใน `generate_signals`
- อัปเดต AGENTS และ changelog