### PR TITLE
Patch v6.7 add lot cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,4 +183,6 @@
 - เพิ่มฟังก์ชัน `generate_signals_v6_5` ปรับ threshold ตาม ATR และ fold_id
 ### 2025-07-14
 - ปรับ `generate_signals_v6_5` ให้ปิดกรองเวลาเมื่อ fold_id = 4 (Patch v6.6)
+### 2025-07-15
+- กำหนดเพดานลอตที่ 1.0 และปรับฟังก์ชัน risk/backtester ให้ตรวจสอบค่านี้ (Patch v6.7)
 

--- a/changelog.md
+++ b/changelog.md
@@ -159,4 +159,6 @@
 - เพิ่ม unit test สำหรับฟังก์ชันใหม่
 ## 2025-07-14
 - ปรับ `generate_signals_v6_5` ปิดกรอง session เมื่อ fold_id=4 (Patch v6.6)
+## 2025-07-15
+- เพิ่ม MAX_LOT_CAP จำกัด lot ไม่เกิน 1.0 และปรับ risk/backtester ตรวจสอบค่าดังกล่าว (Patch v6.7)
 

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -170,6 +170,7 @@ def run_backtest(df: pd.DataFrame):
                 lot = calc_lot_recovery(capital, atr_val, 1.5)
             else:
                 lot = calc_lot_risk(capital, atr_val, 1.5)
+            lot = min(lot, 1.0)  # [Patch v6.7] ensure cap
             open_trade = {
                 "entry": price,
                 "entry_time": ts,

--- a/nicegold_v5/risk.py
+++ b/nicegold_v5/risk.py
@@ -1,8 +1,10 @@
+MAX_LOT_CAP = 1.0  # [Patch v6.7]
+
 def calc_lot(capital: float, risk_pct: float = 1.5, sl_pips: float = 100) -> float:
     risk_amount = capital * (risk_pct / 100)
     pip_value = 10  # For gold 0.1/point × 100 = $10/lot
     lot = risk_amount / (sl_pips * pip_value)
-    return max(0.01, round(lot, 2))
+    return min(MAX_LOT_CAP, max(0.01, round(lot, 2)))  # [Patch v6.7]
 
 
 # --- Patch C: Advanced Risk Management ---
@@ -57,7 +59,7 @@ def calc_lot_risk(capital: float, atr: float, risk_pct: float = 1.5) -> float:
     sl_pips = atr * 10
     risk_amount = capital * (risk_pct / 100)
     lot = risk_amount / (sl_pips * pip_value)
-    return max(0.01, round(lot, 2))
+    return min(MAX_LOT_CAP, max(0.01, round(lot, 2)))  # [Patch v6.7]
 
 
 # --- Patch B.2: Recovery Mode Risk Logic ---
@@ -68,7 +70,7 @@ def calc_lot_recovery(capital: float, atr: float, risk_pct: float = 1.5) -> floa
     """Adaptive lot size เมื่ออยู่ใน Recovery Mode (lot × 1.5)."""
     base_lot = calc_lot_risk(capital, atr, risk_pct)
     recovery_lot = base_lot * 1.5
-    return max(0.01, round(recovery_lot, 2))
+    return min(MAX_LOT_CAP, max(0.01, round(recovery_lot, 2)))  # [Patch v6.7]
 
 
 def get_sl_tp_recovery(price: float, atr: float, direction: str) -> tuple[float, float]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ from nicegold_v5.risk import (
     calc_lot_risk,
     get_sl_tp,
     get_sl_tp_recovery,
+    MAX_LOT_CAP,
 )
 from nicegold_v5.exit import should_exit
 from nicegold_v5.backtester import run_backtest
@@ -157,6 +158,7 @@ def test_auto_entry_config():
 def test_calc_lot():
     lot = calc_lot(100)
     assert lot >= 0.01
+    assert lot <= MAX_LOT_CAP
 
 
 def test_kill_switch_trigger():
@@ -179,6 +181,7 @@ def test_calc_lot_risk_and_sl_tp():
     lot = calc_lot_risk(1000, 1.0, 1.5)
     assert sl < 100 and tp > 100
     assert lot >= 0.01
+    assert lot <= MAX_LOT_CAP
 
 
 def test_get_sl_tp_recovery():


### PR DESCRIPTION
## Notes
- เพิ่ม MAX_LOT_CAP และแก้ฟังก์ชัน risk ให้จำกัด lot
- ปรับ backtester ให้คุมขนาด lot ตอนเปิดไม้
- อัปเดตการทดสอบให้ตรวจสอบเพดาน lot

## Testing
- `pytest -q` ผ่านทั้งหมด