### PR TITLE
Patch v8.1.1 - Optuna objective & skip backtest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,8 @@
 - ปรับ sniper_zone ใช้ confirm_zone และเพิ่ม tp1_rr_ratio, use_dynamic_tsl (Patch v8.0)
 - breakout_up ดีเลย์ 2 แท่ง (Patch v8.0)
 
+### 2025-07-23
+- แก้คำเตือน fillna ใน sniper_risk_score และเพิ่ม config ให้ generate_signals (Patch v8.1.1)
+- เพิ่มเงื่อนไขข้าม backtest หากสัญญาณถูกบล็อกทั้งหมด
+- เพิ่มฟังก์ชัน objective() และ start_optimization สำหรับ Optuna
+

--- a/changelog.md
+++ b/changelog.md
@@ -190,3 +190,7 @@
 - ปรับ sniper_zone ใช้ confirm_zone และเพิ่ม tp1_rr_ratio, use_dynamic_tsl (Patch v8.0)
 - breakout_up ใช้ delay 2 แท่ง (Patch v8.0)
 
+## 2025-07-23
+- แก้คำเตือน fillna ใน sniper_risk_score และเพิ่มพารามิเตอร์ config ให้ generate_signals (Patch v8.1.1)
+- เพิ่มฟังก์ชัน objective() สำหรับ Optuna และเงื่อนไข skip backtest หากไม่มีสัญญาณ
+

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -17,3 +17,4 @@ from .wfv import (
     build_trade_log,
 )
 from .config import ENTRY_CONFIG_PER_FOLD
+from optuna_tuner import start_optimization, objective

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -33,6 +33,10 @@ def run_backtest(df: pd.DataFrame):
     recovery_mode = False  # เริ่มแบบปกติ
     start = time.time()
 
+    if df["entry_signal"].isnull().mean() == 1.0:
+        print("⚠️ All signals blocked. Skipping backtest.")
+        return pd.DataFrame(), pd.DataFrame()
+
     if MAX_RAM_MODE:
         df = df.astype({col: np.float32 for col in df.select_dtypes(include="number").columns})
 

--- a/optuna_tuner.py
+++ b/optuna_tuner.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import optuna
+from nicegold_v5.entry import generate_signals
+from nicegold_v5.backtester import run_backtest
+from nicegold_v5.utils import print_qa_summary, split_by_session
+
+session_folds: dict[str, pd.DataFrame] = {}
+
+
+def objective(trial) -> float:
+    config = {
+        "gain_z_thresh": trial.suggest_float("gain_z_thresh", -0.1, 0.6),
+        "ema_slope_min": trial.suggest_float("ema_slope_min", 0.0, 0.4),
+        "atr_thresh": trial.suggest_float("atr_thresh", 0.5, 1.2),
+        "sniper_risk_score_min": trial.suggest_float("sniper_risk_score_min", 5.0, 7.5),
+        "tp_rr_ratio": trial.suggest_float("tp_rr_ratio", 4.0, 8.0),
+        "volume_ratio": trial.suggest_float("volume_ratio", 0.7, 1.2),
+    }
+
+    df = session_folds.get("London", pd.DataFrame()).copy()
+    if df.empty:
+        return -999
+    df = generate_signals(df, config=config)
+    trades, equity = run_backtest(df)
+
+    if trades.empty:
+        return -999
+
+    metrics = print_qa_summary(trades, equity)
+    profit = metrics.get("total_profit", 0)
+    drawdown = metrics.get("max_drawdown", 0)
+    avg_pnl = metrics.get("avg_pnl", 0)
+
+    score = profit - drawdown * 1.5 + avg_pnl * 5
+    return score
+
+
+def start_optimization(df: pd.DataFrame, n_trials: int = 50):
+    global session_folds
+    session_folds = split_by_session(df)
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=n_trials)
+    print("✅ Best trial:")
+    print(study.best_trial)
+    return study

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -396,3 +396,17 @@ def test_print_qa_summary_and_export(tmp_path):
     export_chatgpt_ready_logs(trades, equity, summary, outdir=str(tmp_path))
     files = list(tmp_path.iterdir())
     assert len(files) == 3
+
+
+def test_backtest_skip_all_blocked():
+    df = sample_df()
+    df["entry_signal"] = None
+    trades, equity = run_backtest(df)
+    assert trades.empty and equity.empty
+
+
+def test_optuna_objective():
+    import optuna_tuner as tuner
+    df = sample_df()
+    study = tuner.start_optimization(df, n_trials=1)
+    assert len(study.trials) == 1


### PR DESCRIPTION
## Summary
- fix pandas inplace warning for `sniper_risk_score`
- allow `generate_signals` to take tuning config
- skip `run_backtest` when all signals blocked
- add Optuna tuning helper with `objective()`
- add tests for skip logic and optuna objective
- update documentation

## Testing
- `pytest -q`