### PR TITLE
Update generate_signals wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,3 +229,6 @@
 ### 2025-07-25
 - ปรับคอมเมนต์ Patch v8.1.3 ในเมนู [4] ให้ตรงตามดีฟ
 
+
+### 2025-07-26
+- ยกเลิก fallback UltraFix และให้ generate_signals เรียกใช้ logic sniper v8.0 (Patch v8.1.4)

--- a/changelog.md
+++ b/changelog.md
@@ -204,3 +204,6 @@
 ## 2025-07-25
 - ปรับคอมเมนต์เมนู [4] สำหรับ Patch v8.1.3 ให้ตรงตามดีฟ
 
+
+## 2025-07-26
+- ยกเลิก fallback UltraFix และให้ generate_signals เรียกใช้ generate_signals_v8_0 (Patch v8.1.4)

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -1,4 +1,4 @@
-from .entry import generate_signals, generate_signals_v8_0
+from .entry import generate_signals_v8_0, generate_signals  # [Patch v8.1.4] ensure v8.0 available
 from .risk import calc_lot
 from .exit import should_exit
 from .backtester import run_backtest

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -13,8 +13,8 @@ def rsi(series: pd.Series, period: int = 14) -> pd.Series:
     return 100 - (100 / (1 + rs))
 
 
-def generate_signals(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:
-    """Patch VBTB+ UltraFix v4.1 – QA Enterprise Ready"""
+def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:
+    """ใช้ logic sniper + TP1/TSL แบบล่าสุด (Patch v8.0)."""
     df = df.copy()
 
     config = config or {}
@@ -161,8 +161,7 @@ def generate_signals(df: pd.DataFrame, config: dict | None = None) -> pd.DataFra
     )
     df.loc[df["entry_signal"].notnull(), "entry_blocked_reason"] = None
     blocked_pct = df["entry_signal"].isnull().mean() * 100
-    print(f"[Patch VBTB+ UltraFix v4.1] Entry Signal Blocked: {blocked_pct:.2f}%")
-
+    print(f"[Patch v8.0] Entry Signal Blocked: {blocked_pct:.2f}%")
     return df
 
 
@@ -319,11 +318,11 @@ def generate_signals_v7_1(df: pd.DataFrame, config: dict | None = None) -> pd.Da
     return df
 
 
-# --- Patch v8.0 ---
+# --- Patch v8.1.4 ---
 
 
-def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:
-    """ใช้ logic sniper + TP1/TSL แบบล่าสุด (Patch v8.0)."""
-    return generate_signals(df, config=config)
+def generate_signals(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:
+    """[Patch v8.1.4] Fallback ถูกยกเลิก — forward ไปยัง logic sniper v8.0"""
+    return generate_signals_v8_0(df, config=config)  # ใช้ sniper confirm zone, risk score, delay, TP boost เท่านั้น
 
 


### PR DESCRIPTION
## Notes
- ปิด fallback UltraFix v4.1 แล้วเรียกตรงฟังก์ชัน sniper v8.0 แทน

## Summary
- เปลี่ยนชื่อฟังก์ชัน `generate_signals` เดิมเป็น `generate_signals_v8_0`
- เพิ่ม wrapper ใหม่ให้ `generate_signals` เรียก `generate_signals_v8_0`
- อัปเดต `__init__.py`, AGENTS และ changelog

## Testing
- `pytest -q`