### PR TITLE
Patch v8.1.5: default sniper config for CLI menu 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,3 +232,5 @@
 
 ### 2025-07-26
 - ยกเลิก fallback UltraFix และให้ generate_signals เรียกใช้ logic sniper v8.0 (Patch v8.1.4)
+### 2025-07-27
+- เพิ่ม SNIPER_CONFIG_DEFAULT ใน config.py และส่งไป main.py เมนู [4] (Patch v8.1.5)

--- a/changelog.md
+++ b/changelog.md
@@ -207,3 +207,5 @@
 
 ## 2025-07-26
 - ยกเลิก fallback UltraFix และให้ generate_signals เรียกใช้ generate_signals_v8_0 (Patch v8.1.4)
+## 2025-07-27
+- เพิ่ม SNIPER_CONFIG_DEFAULT ใน config.py และส่งให้ main.py เมนู 4 (Patch v8.1.5)

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from multiprocessing import cpu_count, get_context
 import numpy as np
 from nicegold_v5.utils import run_auto_wfv, split_by_session
 from nicegold_v5.entry import generate_signals_v8_0 as generate_signals  # [Patch v8.1.2] ใช้ logic sniper + TP1/TSL แบบล่าสุด
+from nicegold_v5.config import SNIPER_CONFIG_DEFAULT  # [Patch v8.1.5]
 
 # --- Advanced Risk Management (Patch C) ---
 KILL_SWITCH_DD = 25  # %
@@ -259,6 +260,7 @@ def welcome():
         from nicegold_v5.entry import (
             generate_signals_v8_0 as generate_signals
         )  # [Patch v8.1.3] เปลี่ยนจาก logic v4.1 เป็น v8.0 ที่เจ้านายระบุ
+        from nicegold_v5.config import SNIPER_CONFIG_DEFAULT  # [Patch v8.1.5]
         from nicegold_v5.backtester import run_backtest
         from nicegold_v5.utils import (
             print_qa_summary,
@@ -268,7 +270,7 @@ def welcome():
         import time
 
         # [Patch] Inject signal + run with updated SL/TP1/TP2/BE
-        df = generate_signals(df)
+        df = generate_signals(df, config=SNIPER_CONFIG_DEFAULT)  # [Patch v8.1.5] ส่ง config sniper entry แบบกำไรจริง
         start = time.time()
         trades, equity = run_backtest(df)
         end = time.time()

--- a/nicegold_v5/config.py
+++ b/nicegold_v5/config.py
@@ -7,3 +7,13 @@ ENTRY_CONFIG_PER_FOLD = {
     4: {"gain_z_thresh": -0.05, "ema_slope_min": 0.01},
     5: {"gain_z_thresh": -0.15, "ema_slope_min": 0.001},
 }
+
+# [Patch v8.1.5] Default Sniper Config สำหรับใช้ใน main.py menu 4
+SNIPER_CONFIG_DEFAULT = {
+    "gain_z_thresh": -0.05,
+    "ema_slope_min": 0.05,
+    "atr_thresh": 0.5,
+    "sniper_risk_score_min": 5.5,
+    "tp_rr_ratio": 6.0,
+    "volume_ratio": 0.8,
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def test_welcome_manual_backtest(monkeypatch, capsys, tmp_path):
 
     monkeypatch.setattr(
         'nicegold_v5.entry.generate_signals_v8_0',
-        lambda df: df.assign(entry_signal='buy'),
+        lambda df, config=None: df.assign(entry_signal='buy'),
     )
 
     def fake_run_backtest(df):


### PR DESCRIPTION
## Summary
- add `SNIPER_CONFIG_DEFAULT` in `config.py`
- import and apply this config in menu 4 of `main.py`
- adjust CLI test for the new argument
- update patch history and changelog

## Testing
- `pytest -q`