### PR TITLE
Patch v8.1.7 override sniper config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,3 +236,5 @@
 - เพิ่ม SNIPER_CONFIG_DEFAULT ใน config.py และส่งไป main.py เมนู [4] (Patch v8.1.5)
 ### 2025-07-28
 - เพิ่ม SNIPER_CONFIG_RELAXED และ fallback ใน main.py เมื่อไม่มีสัญญาณ (Patch v8.1.6)
+### 2025-07-29
+- ปรับ confirm_zone ผ่อนปรน และเพิ่ม SNIPER_CONFIG_OVERRIDE สำหรับ fallback (Patch v8.1.7)

--- a/changelog.md
+++ b/changelog.md
@@ -211,3 +211,5 @@
 - เพิ่ม SNIPER_CONFIG_DEFAULT ใน config.py และส่งให้ main.py เมนู 4 (Patch v8.1.5)
 ## 2025-07-28
 - เพิ่ม SNIPER_CONFIG_RELAXED และ fallback ใน main.py เมื่อไม่มีสัญญาณ (Patch v8.1.6)
+## 2025-07-29
+- ปรับ confirm_zone และคะแนน Sniper ให้ผ่อนปรน พร้อม config override (Patch v8.1.7)

--- a/main.py
+++ b/main.py
@@ -275,8 +275,8 @@ def welcome():
         # [Patch v8.1.6] Fallback เมื่อไม่มี entry_signal เลย
         if df["entry_signal"].isnull().mean() == 1.0:
             print("⚠️ [Patch v8.1.6] No signals found – applying relaxed sniper config...")
-            from nicegold_v5.config import SNIPER_CONFIG_RELAXED
-            df = generate_signals(df, config=SNIPER_CONFIG_RELAXED)
+            from nicegold_v5.config import SNIPER_CONFIG_OVERRIDE  # [Patch v8.1.7]
+            df = generate_signals(df, config=SNIPER_CONFIG_OVERRIDE)
         start = time.time()
         trades, equity = run_backtest(df)
         end = time.time()

--- a/nicegold_v5/config.py
+++ b/nicegold_v5/config.py
@@ -27,3 +27,13 @@ SNIPER_CONFIG_RELAXED = {
     "tp_rr_ratio": 5.0,
     "volume_ratio": 0.6,
 }
+
+# [Patch v8.1.7] Override sniper config สำหรับ fallback กรณีบล็อกสัญญาณ 100%
+SNIPER_CONFIG_OVERRIDE = {
+    "gain_z_thresh": -0.3,
+    "ema_slope_min": -0.01,
+    "atr_thresh": 0.2,
+    "sniper_risk_score_min": 2.5,
+    "tp_rr_ratio": 4.5,
+    "volume_ratio": 0.4,
+}

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -21,7 +21,7 @@ def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.Da
     gain_z_thresh = config.get("gain_z_thresh", 0.25)
     ema_slope_min = config.get("ema_slope_min", 0.2)
     atr_thresh_val = config.get("atr_thresh", 1.0)
-    sniper_risk_score_min = config.get("sniper_risk_score_min", 6.0)
+    sniper_risk_score_min = config.get("sniper_risk_score_min", 2.5)  # [Patch v8.1.7]
     tp_rr_ratio_cfg = config.get("tp_rr_ratio", 4.8)
     volume_ratio = config.get("volume_ratio", 1.0)
     df["entry_signal"] = None
@@ -100,13 +100,12 @@ def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.Da
         df["entry_score"].rank(method="first"), q=3, labels=["C", "B", "A"], duplicates="drop"
     )
     df["confirm_zone"] = (
-        (df["gain_z"] > 0.0) &
-        (df["ema_slope"] > 0.15) &
-        ((df["atr"] > 0.8) | ((df["atr"] / df["atr_ma"]) > 0.95)) &
-        (df["volume"] > df["volume_ma"]) &
-        (((df["entry_tier"].isin(["A", "B"])) & (df["rsi_14"] > 51) & (df["entry_score"] > 0)) |
-         ((df["entry_tier"].isin(["A", "B"])) & (df["rsi_14"] < 49) & (df["entry_score"] > 0)))
-    )  # [Patch v7.9]
+        (df["gain_z"] > -0.15) &
+        (df["ema_slope"] > -0.01) &
+        ((df["atr"] > 0.2) | ((df["atr"] / df["atr_ma"]) > 0.75)) &
+        ((df["volume"] > df["volume_ma"] * 0.4) | (df["volume"].isna())) &
+        (df["entry_score"] > 0)
+    )  # [Patch v8.1.7] Adaptive ConfirmZone
 
     sniper_zone = (
         (df["sniper_risk_score"] >= sniper_risk_score_min)


### PR DESCRIPTION
## Notes
- ปรับค่า `confirm_zone` และ `sniper_risk_score_min` ใน `generate_signals_v8_0`
- เพิ่ม `SNIPER_CONFIG_OVERRIDE` สำหรับ fallback
- เมนู backtest ใช้ค่า override เมื่อไม่มีสัญญาณ
- อัพเดต AGENTS.md และ changelog

## Testing
- `pytest -q`