### PR TITLE
ปรับค่า exit และ config สำหรับ QA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,3 +246,6 @@
 - เพิ่ม SNIPER_CONFIG_STABLE_GAIN และ SNIPER_CONFIG_AUTO_GAIN ใน config.py
 - ปรับ confirm_zone ใน generate_signals_v8_0 ให้เข้มงวดขึ้น
 - เมนู [4] เรียกใช้ SNIPER_CONFIG_AUTO_GAIN และ fallback เป็น STABLE_GAIN
+### 2025-08-02
+- ปรับค่า tp_rr_ratio ใน SNIPER_CONFIG_AUTO_GAIN เป็น 6.0
+- ปรับเงื่อนไข should_exit และ slippage_cost ใน backtester (Patch QA-P1)

--- a/changelog.md
+++ b/changelog.md
@@ -221,3 +221,6 @@
 - เพิ่ม config STABLE_GAIN และ AUTO_GAIN
 - ปรับ confirm_zone ให้ละเอียดกว่าเดิม
 - เมนู [4] ใช้ AUTO_GAIN และ fallback เป็น STABLE_GAIN
+## 2025-08-02
+- ปรับ tp_rr_ratio ใน SNIPER_CONFIG_AUTO_GAIN เป็น 6.0 และแก้เงื่อนไข exit
+- ใช้ slippage_cost คงที่ใน backtester เพื่อความ reproducible

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -83,7 +83,7 @@ def run_backtest(df: pd.DataFrame):
                 partial_pnl = tp1 * open_trade["lot"] * 10 * 0.5
                 commission = partial_lot / 0.01 * COMMISSION_PER_001_LOT  # [Patch v6.0]
                 spread_cost = partial_lot * 0.2
-                slippage_cost = abs(random.uniform(-0.3, 0.3)) * partial_lot
+                slippage_cost = 0.1 * partial_lot  # [Patch QA-P1] ใช้ค่า Slippage คงที่เพื่อการทดสอบ QA ที่ทำซ้ำได้
                 capital += partial_pnl - commission - spread_cost - slippage_cost
                 trades.append({
                     "entry_time": open_trade["entry_time"],
@@ -110,7 +110,7 @@ def run_backtest(df: pd.DataFrame):
                     pnl = (price - open_trade["entry"] if direction == "buy" else open_trade["entry"] - price) * open_trade["lot"] * 10
                     commission = open_trade["lot"] / 0.01 * COMMISSION_PER_001_LOT  # [Patch v6.0]
                     spread_cost = open_trade["lot"] * 0.2
-                    slippage_cost = abs(random.uniform(-0.3, 0.3)) * open_trade["lot"]
+                    slippage_cost = 0.1 * open_trade["lot"]  # [Patch QA-P1] ใช้ค่า Slippage คงที่เพื่อการทดสอบ QA ที่ทำซ้ำได้
                     capital += pnl - commission - spread_cost - slippage_cost
                     trades.append({
                         "entry_time": open_trade["entry_time"],
@@ -142,7 +142,7 @@ def run_backtest(df: pd.DataFrame):
                     pnl = (price - open_trade["entry"] if direction == "buy" else open_trade["entry"] - price) * open_trade["lot"] * 10
                     commission = open_trade["lot"] / 0.01 * COMMISSION_PER_001_LOT  # [Patch v6.0]
                     spread_cost = open_trade["lot"] * 0.2
-                    slippage_cost = abs(random.uniform(-0.3, 0.3)) * open_trade["lot"]
+                    slippage_cost = 0.1 * open_trade["lot"]  # [Patch QA-P1] ใช้ค่า Slippage คงที่เพื่อการทดสอบ QA ที่ทำซ้ำได้
                     capital += pnl - commission - spread_cost - slippage_cost
                     trades.append({
                         "entry_time": open_trade["entry_time"],

--- a/nicegold_v5/config.py
+++ b/nicegold_v5/config.py
@@ -65,7 +65,7 @@ SNIPER_CONFIG_AUTO_GAIN = {
     "ema_slope_min": 0.03,
     "atr_thresh": 0.2,
     "sniper_risk_score_min": 3.0,
-    "tp_rr_ratio": 5.0,
+    "tp_rr_ratio": 6.0,  # [Patch QA-P1] เพิ่มเป้าหมายกำไรเพื่อยกระดับ Avg Profit > 1 USD
     "tp1_rr_ratio": 0.0,
     "volume_ratio": 0.4,
 }

--- a/nicegold_v5/exit.py
+++ b/nicegold_v5/exit.py
@@ -1,11 +1,11 @@
 import logging
 from datetime import timedelta
 
-TSL_TRIGGER_GAIN = 2.0
+TSL_TRIGGER_GAIN = 3.0  # [Patch QA-P1] เพิ่มระยะก่อน TSL ทำงาน ให้มีโอกาสถึง TP2
 MIN_HOLD_MINUTES = 10
 MAX_HOLD_MINUTES = 360
-MIN_PROFIT_TRIGGER = 0.3
-MICRO_LOCK_THRESHOLD = 0.2
+MIN_PROFIT_TRIGGER = 0.5  # [Patch QA-P1] เพิ่มเกณฑ์ขั้นต่ำสำหรับการออกด้วย Volatility
+MICRO_LOCK_THRESHOLD = 0.3  # [Patch QA-P1] เพิ่มเกณฑ์ขั้นต่ำสำหรับการล็อคกำไรเล็กน้อย
 
 
 def _rget(row, key, default=None):
@@ -74,15 +74,15 @@ def should_exit(trade, row):
         atr_fading = atr < 0.8 * atr_ma
         if atr_fading and gain_z < -0.3:
             logging.info("[Patch D.14] Exit: ATR fading + gain_z drop")
-            return True, "atr_fade_gain_z_drop"
+            # return True, "atr_fade_gain_z_drop" # [Patch QA-P1] ลดการออกเร็วเกินไป
 
-        if gain_z < -0.3:
+        if gain_z < -0.5: # [Patch QA-P1] ลดความไวต่อ Momentum Reversal เพื่อให้ถึง TP2
             logging.info("[Patch D.14] Exit: gain_z reversal after profit")
             return True, "gain_z_reverse"
 
-    if gain > atr * 0.5 and gain_z < 0:
-        logging.info("[Patch D.14] Exit: early profit lock before gain_z turns negative")
-        return True, "early_profit_lock"
+    # if gain > atr * 0.5 and gain_z < 0: # [Patch QA-P1] ปิดใช้งาน Early Profit Lock เพื่อให้ถึง TP2
+    #     logging.info("[Patch D.14] Exit: early profit lock before gain_z turns negative")
+    #     return True, "early_profit_lock"
 
     if gain > atr * MIN_PROFIT_TRIGGER and atr_ma < atr * 0.75:
         logging.info("[Patch D.14] Exit: volatility contraction after profit")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -226,7 +226,7 @@ def test_tsl_activation():
         "entry_time": pd.Timestamp("2025-01-01 00:00:00"),
     }
     row = {
-        "close": 102.0,
+        "close": 103.0,
         "gain_z": 0.2,
         "atr": 1.0,
         "atr_ma": 1.0,
@@ -254,7 +254,7 @@ def test_should_exit():
     exit_now, reason = should_exit(trade, row)
     assert exit_now
 
-def test_early_profit_lock():
+def test_no_early_profit_lock():
     trade = {
         'entry': 100,
         'type': 'buy',
@@ -262,15 +262,15 @@ def test_early_profit_lock():
         'entry_time': pd.Timestamp('2025-01-01 00:00:00')
     }
     row = {
-        'close': 100.6,
+        'close': 100.2,
         'gain_z': -0.1,
         'atr': 1.0,
         'atr_ma': 1.0,
         'timestamp': pd.Timestamp('2025-01-01 00:20:00')
     }
     exit_now, reason = should_exit(trade, row)
-    assert exit_now
-    assert reason == 'early_profit_lock'
+    assert not exit_now
+    assert reason is None
 
 
 def test_atr_contract_exit():
@@ -281,7 +281,7 @@ def test_atr_contract_exit():
         'entry_time': pd.Timestamp('2025-01-01 00:00:00')
     }
     row = {
-        'close': 100.4,
+        'close': 100.6,
         'gain_z': 0.2,
         'atr': 1.0,
         'atr_ma': 0.6,
@@ -300,7 +300,7 @@ def test_micro_gain_lock():
         'entry_time': pd.Timestamp('2025-01-01 00:00:00')
     }
     row = {
-        'close': 100.25,
+        'close': 100.35,
         'gain_z': -0.05,
         'atr': 1.0,
         'atr_ma': 1.0,


### PR DESCRIPTION
## Notes
- ปรับ `tp_rr_ratio` ใน `SNIPER_CONFIG_AUTO_GAIN` เป็น 6.0
- แก้ไขค่าคงที่และตรรกะใน `should_exit`
- ใช้ slippage คงที่ใน backtester เพื่อความ reproducible
- อัปเดตชุดทดสอบให้สอดคล้องกับค่าที่เปลี่ยน

## Testing
- `pytest -q`