### PR TITLE
Patch G.7 timestamp export

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -305,3 +305,5 @@
 ### 2025-08-23
 - รวมฟังก์ชัน patch_h_backtester_logging เข้ากับ `backtester.py`
 - ลบไฟล์ patch แยกและปรับ unit test ให้ import จาก backtester
+### 2025-08-24
+- ปรับ auto_qa_after_backtest ให้เพิ่ม timestamp ในชื่อไฟล์เพื่อป้องกัน overwrite (Patch G.7)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -281,3 +281,5 @@
 ## 2025-08-23
 - รวมฟังก์ชัน patch_h_backtester_logging เข้ากับ backtester.py
 - ปรับ unit test ให้นำเข้าเมธอดจาก backtester
+## 2025-08-24
+- ปรับ auto_qa_after_backtest เพิ่ม timestamp ในชื่อไฟล์ป้องกันถูกเขียนทับ (Patch G.7)

--- a/nicegold_v5/patch_g5_auto_qa.py
+++ b/nicegold_v5/patch_g5_auto_qa.py
@@ -10,16 +10,19 @@ from .patch_g4_fold_export_drift import export_fold_qa, detect_fold_drift
 
 
 def auto_qa_after_backtest(trades: pd.DataFrame, equity: pd.DataFrame, label: str = "Run"):
-    """Automatically export QA summary after backtest."""
+    """Automatically export QA summary after backtest with timestamp-enhanced label."""
     if trades.empty:
         print("❌ ไม่มีข้อมูล trades สำหรับ QA")
         return
 
-    stats = summarize_fold(trades, label)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    label_full = f"{label}_{timestamp}"
+
+    stats = summarize_fold(trades, label_full)
     bias = compute_fold_bias(trades)
     dd = analyze_drawdown(equity)
-    export_fold_qa(label, stats, bias, dd, outdir="logs/qa")
+    export_fold_qa(label_full, stats, bias, dd, outdir="logs/qa")
 
-    save_csv_path = os.path.join("logs/qa", f"fold_qa_{label.lower()}.csv")
+    save_csv_path = os.path.join("logs/qa", f"fold_qa_{label_full.lower()}.csv")
     pd.DataFrame([stats | {"bias_score": bias} | dd]).to_csv(save_csv_path, index=False)
     print(f"✅ QA Auto Export → {save_csv_path}")

--- a/nicegold_v5/tests/test_qa_guard.py
+++ b/nicegold_v5/tests/test_qa_guard.py
@@ -85,5 +85,7 @@ def test_auto_qa_after_backtest(tmp_path, monkeypatch):
     equity = pd.DataFrame({'equity': [100, 101, 99]})
     monkeypatch.chdir(tmp_path)
     auto_qa_after_backtest(trades, equity, label='X')
-    assert (tmp_path / 'logs' / 'qa' / 'fold_qa_x.csv').exists()
-    assert (tmp_path / 'logs' / 'qa' / 'fold_qa_x.json').exists()
+    csv_files = list((tmp_path / 'logs' / 'qa').glob('fold_qa_x_*.csv'))
+    json_files = list((tmp_path / 'logs' / 'qa').glob('fold_qa_x_*.json'))
+    assert len(csv_files) == 1
+    assert len(json_files) == 1


### PR DESCRIPTION
## Notes
- ปรับฟังก์ชัน `auto_qa_after_backtest` เพิ่ม timestamp ต่อท้าย label ทำให้ไฟล์ไม่ถูกเขียนทับ
- ปรับ unit test ให้ตรวจสอบไฟล์ที่มี timestamp
- อัปเดต `AGENTS.md` และ `changelog.md`

## Summary
- เพิ่ม timestamp ในชื่อไฟล์ QA summary เพื่อป้องกัน overwrite
- ปรับการทดสอบให้ค้นหาไฟล์ด้วย wildcard

## Testing
- `pytest -q`