### PR TITLE
Patch G.8 fix QA export path

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -307,3 +307,5 @@
 - ลบไฟล์ patch แยกและปรับ unit test ให้ import จาก backtester
 ### 2025-08-24
 - ปรับ auto_qa_after_backtest ให้เพิ่ม timestamp ในชื่อไฟล์เพื่อป้องกัน overwrite (Patch G.7)
+### 2025-08-25
+- Fix QA Export Path ให้ใช้ absolute path บันทึกที่ `/content/drive/MyDrive/NICEGOLD/logs/qa` (Patch G.8)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -283,3 +283,5 @@
 - ปรับ unit test ให้นำเข้าเมธอดจาก backtester
 ## 2025-08-24
 - ปรับ auto_qa_after_backtest เพิ่ม timestamp ในชื่อไฟล์ป้องกันถูกเขียนทับ (Patch G.7)
+## 2025-08-25
+- Fix QA Export Path ใช้ absolute path `/content/drive/MyDrive/NICEGOLD/logs/qa` (Patch G.8)

--- a/nicegold_v5/patch_g5_auto_qa.py
+++ b/nicegold_v5/patch_g5_auto_qa.py
@@ -8,6 +8,10 @@ from .patch_phase3_qa_guard import (
 )
 from .patch_g4_fold_export_drift import export_fold_qa, detect_fold_drift
 
+# [Patch G.8] ใช้ path เต็มที่มองเห็นได้ใน Colab
+QA_BASE_PATH = "/content/drive/MyDrive/NICEGOLD/logs/qa"
+os.makedirs(QA_BASE_PATH, exist_ok=True)
+
 
 def auto_qa_after_backtest(trades: pd.DataFrame, equity: pd.DataFrame, label: str = "Run"):
     """Automatically export QA summary after backtest with timestamp-enhanced label."""
@@ -21,8 +25,8 @@ def auto_qa_after_backtest(trades: pd.DataFrame, equity: pd.DataFrame, label: st
     stats = summarize_fold(trades, label_full)
     bias = compute_fold_bias(trades)
     dd = analyze_drawdown(equity)
-    export_fold_qa(label_full, stats, bias, dd, outdir="logs/qa")
+    export_fold_qa(label_full, stats, bias, dd, outdir=QA_BASE_PATH)
 
-    save_csv_path = os.path.join("logs/qa", f"fold_qa_{label_full.lower()}.csv")
+    save_csv_path = os.path.join(QA_BASE_PATH, f"fold_qa_{label_full.lower()}.csv")
     pd.DataFrame([stats | {"bias_score": bias} | dd]).to_csv(save_csv_path, index=False)
     print(f"✅ QA Auto Export → {save_csv_path}")

--- a/nicegold_v5/tests/test_qa_guard.py
+++ b/nicegold_v5/tests/test_qa_guard.py
@@ -10,6 +10,7 @@ from nicegold_v5.patch_phase3_qa_guard import (
     analyze_drawdown,
 )
 from nicegold_v5.patch_g4_fold_export_drift import export_fold_qa, detect_fold_drift
+import nicegold_v5.patch_g5_auto_qa as patch_g5_auto_qa
 from nicegold_v5.patch_g5_auto_qa import auto_qa_after_backtest
 
 
@@ -83,9 +84,11 @@ def test_detect_fold_drift():
 def test_auto_qa_after_backtest(tmp_path, monkeypatch):
     trades = sample_trades()
     equity = pd.DataFrame({'equity': [100, 101, 99]})
-    monkeypatch.chdir(tmp_path)
+    qa_path = tmp_path / 'qa'
+    monkeypatch.setattr(patch_g5_auto_qa, 'QA_BASE_PATH', str(qa_path))
+    os.makedirs(qa_path, exist_ok=True)
     auto_qa_after_backtest(trades, equity, label='X')
-    csv_files = list((tmp_path / 'logs' / 'qa').glob('fold_qa_x_*.csv'))
-    json_files = list((tmp_path / 'logs' / 'qa').glob('fold_qa_x_*.json'))
+    csv_files = list(qa_path.glob('fold_qa_x_*.csv'))
+    json_files = list(qa_path.glob('fold_qa_x_*.json'))
     assert len(csv_files) == 1
     assert len(json_files) == 1


### PR DESCRIPTION
## Notes
- แก้ไขฟังก์ชัน `auto_qa_after_backtest` ให้ใช้ path แบบ absolute
- ปรับชุดทดสอบให้รองรับ path ใหม่
- อัพเดตเอกสาร AGENTS และ changelog สำหรับ Patch G.8

## Testing
- `pytest -q`