### PR TITLE
อัพเดต patch v11.1 เพิ่ม simulate_trades_with_tp

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -311,3 +311,5 @@
 - Fix QA Export Path ให้ใช้ absolute path บันทึกที่ `/content/drive/MyDrive/NICEGOLD/logs/qa` (Patch G.8)
 ### 2025-08-26
 - เพิ่มฟังก์ชัน apply_tp_logic, generate_entry_signal, session_filter และตัวแปร trade_log_fields สำหรับ TP1/TP2 และระบบบันทึกสัญญาณ (Patch v11.1)
+### 2025-08-27
+- เพิ่มฟังก์ชัน simulate_trades_with_tp สำหรับทดสอบ TP1/TP2 และ logging ขั้นสูง (Patch v11.1)

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -9,6 +9,7 @@ from .entry import (
     generate_entry_signal,
     session_filter,
     trade_log_fields,
+    simulate_trades_with_tp,
 )  # [Patch v10.0] expose latest logic
 from .risk import calc_lot
 from .exit import should_exit

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -287,3 +287,5 @@
 - Fix QA Export Path ใช้ absolute path `/content/drive/MyDrive/NICEGOLD/logs/qa` (Patch G.8)
 ## 2025-08-26
 - เพิ่มฟังก์ชัน apply_tp_logic, generate_entry_signal และ session_filter พร้อม trade_log_fields เพื่อใช้งาน TP1/TP2 และ logging (Patch v11.1)
+## 2025-08-27
+- เพิ่มฟังก์ชัน simulate_trades_with_tp สำหรับจำลองเทรดพร้อม TP1/TP2 และบันทึกสัญญาณ (Patch v11.1)

--- a/nicegold_v5/tests/test_patch_v11_logic.py
+++ b/nicegold_v5/tests/test_patch_v11_logic.py
@@ -37,3 +37,25 @@ def test_session_filter():
 def test_trade_log_fields():
     required = {'tp1_price', 'tp2_price', 'mfe', 'duration_min'}
     assert required.issubset(set(trade_log_fields))
+
+
+def test_simulate_trades_with_tp():
+    from nicegold_v5.entry import simulate_trades_with_tp
+
+    df = pd.DataFrame([
+        {
+            'timestamp': pd.Timestamp('2025-01-01 00:00:00'),
+            'close': 100.0,
+            'signal': 'long',
+            'session': 'London',
+            'rsi': 25,
+            'pattern': 'inside_bar',
+        }
+    ])
+
+    trades, logs = simulate_trades_with_tp(df)
+    assert len(trades) == 1
+    assert len(logs) == 1
+    trade = trades[0]
+    assert trade['tp1_price'] > trade['entry_price']
+    assert trade['tp2_price'] > trade['tp1_price']


### PR DESCRIPTION
## Notes
- เพิ่มฟังก์ชัน `simulate_trades_with_tp` ใน `entry.py` สำหรับจำลองเทรดพร้อม TP1/TP2 และระบบบันทึกสัญญาณ
- export ฟังก์ชันใหม่ผ่าน `__init__.py`
- เพิ่ม test ตรวจสอบการทำงานของ simulator ใน `test_patch_v11_logic.py`
- อัพเดต `AGENTS.md` และ `changelog.md` ให้บันทึกแพทช์ล่าสุด

## Testing
- `pytest -q`