### PR TITLE
Add TP1/TP2 backtest option

### DIFF
--- a/main.py
+++ b/main.py
@@ -239,11 +239,12 @@ def welcome():
     print("  3. สรุป Drawdown & Win/Loss Streak")
     print("  4. รัน Backtest จาก Signal (Non-ML)")
     print("  5. ออกจากระบบ")
+    print("  6. รัน Backtest ด้วย simulate_trades_with_tp (TP1/TP2 Logic)")
 
     try:
-        choice = int(input("\n🔧 เลือกเมนู [1-5]: "))
+        choice = int(input("\n🔧 เลือกเมนู [1-6]: "))
     except:
-        print("❌ ต้องใส่เป็นตัวเลข 1–5")
+        print("❌ ต้องใส่เป็นตัวเลข 1–6")
         return
 
     if choice == 1:
@@ -341,6 +342,41 @@ def welcome():
     elif choice == 5:
         show_progress_bar("👋 กำลังออกจากระบบ", steps=2)
         print("👋 ขอบคุณที่ใช้ NICEGOLD. พบกันใหม่!")
+        maximize_ram()
+    elif choice == 6:
+        show_progress_bar("🧪 TP1/TP2 Backtest Mode", steps=3)
+        print("\n⚙️ เริ่มรัน simulate_trades_with_tp() จาก UltraFix Patch...")
+        df = load_csv_safe(M1_PATH)
+        df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+        df = df.sort_values("timestamp")
+
+        from patch_v11x import simulate_trades_with_tp  # ← Patch v11.2 logic
+        trades, logs = simulate_trades_with_tp(df)
+        trade_df = pd.DataFrame(trades)
+
+        out_path = os.path.join(TRADE_DIR, "trades_v11p_tp1tp2.csv")
+        trade_df.to_csv(out_path, index=False)
+        print(f"📦 บันทึกผล TP1/TP2 Trade log ที่: {out_path}")
+
+        tp1_hits = (
+            trade_df["exit_reason"].eq("tp1").sum() if "exit_reason" in trade_df.columns else 0
+        )
+        tp2_hits = (
+            trade_df["exit_reason"].eq("tp2").sum() if "exit_reason" in trade_df.columns else 0
+        )
+        sl_hits = trade_df["exit_reason"].eq("sl").sum()
+        total_pnl = (
+            trade_df["exit_price"].sub(trade_df["entry_price"]).sum()
+            if "exit_price" in trade_df.columns
+            else 0
+        )
+
+        print("\n📊 QA Summary (TP1/TP2):")
+        print(f"   ▸ TP1 Triggered : {tp1_hits}")
+        print(f"   ▸ TP2 Triggered : {tp2_hits}")
+        print(f"   ▸ SL Count      : {sl_hits}")
+        print(f"   ▸ Net PnL       : {total_pnl:.2f} USD")
+
         maximize_ram()
     else:
         print("❌ เลือกเมนูไม่ถูกต้อง")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -313,3 +313,7 @@
 - เพิ่มฟังก์ชัน apply_tp_logic, generate_entry_signal, session_filter และตัวแปร trade_log_fields สำหรับ TP1/TP2 และระบบบันทึกสัญญาณ (Patch v11.1)
 ### 2025-08-27
 - เพิ่มฟังก์ชัน simulate_trades_with_tp สำหรับทดสอบ TP1/TP2 และ logging ขั้นสูง (Patch v11.1)
+### 2025-08-28
+- เพิ่มเมนู [6] รัน simulate_trades_with_tp และบันทึกไฟล์ TP1/TP2 (Patch v11.3)
+### 2025-08-29
+- เพิ่ม QA Summary สำหรับ TP1/TP2 ในเมนู [6] พร้อมบันทึกผลกำไร (Patch v11.4)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -289,3 +289,7 @@
 - เพิ่มฟังก์ชัน apply_tp_logic, generate_entry_signal และ session_filter พร้อม trade_log_fields เพื่อใช้งาน TP1/TP2 และ logging (Patch v11.1)
 ## 2025-08-27
 - เพิ่มฟังก์ชัน simulate_trades_with_tp สำหรับจำลองเทรดพร้อม TP1/TP2 และบันทึกสัญญาณ (Patch v11.1)
+## 2025-08-28
+- เพิ่มเมนู [6] รัน simulate_trades_with_tp และบันทึกไฟล์ TP1/TP2 (Patch v11.3)
+## 2025-08-29
+- เพิ่ม QA Summary สำหรับ TP1/TP2 ในเมนู [6] พร้อมสรุปกำไรสุทธิ (Patch v11.4)

--- a/nicegold_v5/tests/test_cli.py
+++ b/nicegold_v5/tests/test_cli.py
@@ -81,3 +81,28 @@ def test_manual_backtest_diagnostic(monkeypatch, capsys, tmp_path):
     main.welcome()
     output = capsys.readouterr().out
     assert "Injecting Profit Config" in output
+
+def test_tp1_tp2_menu(monkeypatch, capsys, tmp_path):
+    inputs = iter(['6'])
+    monkeypatch.setattr(builtins, "input", lambda prompt='': next(inputs))
+    main = importlib.import_module('main')
+    monkeypatch.setattr(main, "TRADE_DIR", str(tmp_path))
+    monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
+        'timestamp': pd.date_range('2024-01-01', periods=2, freq='h'),
+        'close': [100, 101],
+        'signal': ['long', 'long'],
+        'session': ['London', 'London'],
+        'rsi': [25, 30],
+        'pattern': ['inside_bar', 'inside_bar']
+    }))
+    monkeypatch.setattr('patch_v11x.simulate_trades_with_tp', lambda df: ([{
+        'entry_price': 100,
+        'tp1_price': 105,
+        'tp2_price': 110,
+        'exit_price': 110,
+        'exit_reason': 'tp2'
+    }], []))
+    main.welcome()
+    output = capsys.readouterr().out
+    assert "QA Summary (TP1/TP2)" in output
+    assert "TP2 Triggered" in output

--- a/patch_v11x.py
+++ b/patch_v11x.py
@@ -1,0 +1,3 @@
+from nicegold_v5.entry import simulate_trades_with_tp
+
+__all__ = ["simulate_trades_with_tp"]


### PR DESCRIPTION
## Notes
- เพิ่มเมนู [6] ใน `main.py` เพื่อรัน `simulate_trades_with_tp` พร้อมแสดงสรุป QA
- สร้างโมดูล `patch_v11x.py` สำหรับเรียกใช้ฟังก์ชันดังกล่าว
- อัปเดต `AGENTS.md` และ `changelog.md` ให้มีบันทึก Patch v11.3–v11.4
- เพิ่ม unit test `test_tp1_tp2_menu` ตรวจสอบเมนูใหม่

## Testing
- `pytest -q`