### PR TITLE
Apply Patch v11.6 auto TP1/TP2 simulation

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,19 +235,30 @@ def welcome():
         return
 
     show_progress_bar("📡 เตรียมระบบ", steps=2)
-    print("\n📌 เลือกเมนูที่ต้องการ:")
-    print("  1. รัน Walk-Forward Strategy (ML Based)")
-    print("  2. วิเคราะห์ Session Performance")
-    print("  3. สรุป Drawdown & Win/Loss Streak")
-    print("  4. รัน Backtest จาก Signal (Non-ML)")
-    print("  5. ออกจากระบบ")
-    print("  6. รัน Backtest ด้วย simulate_trades_with_tp (TP1/TP2 Logic)")
+    # [Patch v11.6] Auto-run simulate_trades_with_tp on startup
+    print("🧪 [Patch] ตรวจสอบการทำงานของ TP1/TP2 Simulate Logic")
+    df = load_csv_safe(M1_PATH)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], format=DATETIME_FORMAT, errors="coerce")
+    df = df.sort_values("timestamp")
+    from nicegold_v5.entry import simulate_trades_with_tp
+    trades, logs = simulate_trades_with_tp(df)
+    trade_df = pd.DataFrame(trades)
+    out_path = os.path.join(TRADE_DIR, "trades_v11p_tp1tp2.csv")
+    trade_df.to_csv(out_path, index=False)
+    print(f"[Patch] ✅ บันทึกผล TP1/TP2 Trade log ที่: {out_path}")
 
-    try:
-        choice = int(input("\n🔧 เลือกเมนู [1-6]: "))
-    except:
-        print("❌ ต้องใส่เป็นตัวเลข 1–6")
-        return
+    tp1_hits = trade_df["exit_reason"].eq("tp1").sum() if "exit_reason" in trade_df.columns else 0
+    tp2_hits = trade_df["exit_reason"].eq("tp2").sum() if "exit_reason" in trade_df.columns else 0
+    sl_hits = trade_df["exit_reason"].eq("sl").sum() if "exit_reason" in trade_df.columns else 0
+    total_pnl = safe_calculate_net_change(trade_df)
+
+    print("\n📊 [Patch] QA Summary (TP1/TP2):")
+    print(f"   ▸ TP1 Triggered : {tp1_hits}")
+    print(f"   ▸ TP2 Triggered : {tp2_hits}")
+    print(f"   ▸ SL Count      : {sl_hits}")
+    print(f"   ▸ Net PnL       : {total_pnl:.2f} USD")
+    maximize_ram()
+    return  # Skip menu for automation
 
     if choice == 1:
         print("\n🚀 เริ่มรัน Walk-Forward ML Strategy...")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -335,3 +335,5 @@
 - แก้คำเตือน pandas ใน main.py โดยระบุ DATETIME_FORMAT และเพิ่มชุดทดสอบตรวจสอบการแปลง timestamp
 ### 2025-09-06
 - ลบไฟล์ m.ainmain.py และตัวอย่าง XAUUSD_M1.csv ที่ไม่ได้ใช้
+### 2025-09-07
+- ปรับ welcome ให้รัน simulate_trades_with_tp อัตโนมัติเมื่อเริ่มต้น (Patch v11.6)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -311,3 +311,5 @@
 - ระบุรูปแบบ DATETIME_FORMAT ใน main.py เพื่อป้องกันคำเตือนการแปลงเวลา และเพิ่ม unit test ตรวจสอบ
 ## 2025-09-06
 - ลบไฟล์ที่ไม่ได้ใช้ m.ainmain.py และ XAUUSD_M1.csv
+## 2025-09-07
+- welcome() รัน simulate_trades_with_tp อัตโนมัติ (Patch v11.6)

--- a/nicegold_v5/tests/test_cli.py
+++ b/nicegold_v5/tests/test_cli.py
@@ -1,138 +1,40 @@
-import builtins
 import importlib
 import pandas as pd
 
 
-def test_welcome_menu_exit(monkeypatch, capsys):
-    # Always exit menu by selecting option 5
-    monkeypatch.setattr(builtins, "input", lambda prompt='': '5')
-    main = importlib.import_module('main')
-    main.welcome()
-    output = capsys.readouterr().out
-    assert "NICEGOLD Assistant" in output
-    assert "ออกจากระบบ" in output
-
-
-def test_welcome_manual_backtest(monkeypatch, capsys, tmp_path):
-    inputs = iter(['4'])
-
-    monkeypatch.setattr(builtins, "input", lambda prompt='': next(inputs))
-
-    main = importlib.import_module('main')
-    monkeypatch.setattr(main, "TRADE_DIR", str(tmp_path))
-    monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
-        'timestamp': pd.date_range('2024-01-01', periods=10, freq='h'),
-        'open': [1]*10,
-        'high': [1]*10,
-        'low': [1]*10,
-        'close': [1]*10
-    }))
-
-    monkeypatch.setattr(
-        'nicegold_v5.entry.generate_signals_v8_0',
-        lambda df, config=None: df.assign(entry_signal='buy'),
-    )
-
-    def fake_run_backtest(df):
-        return (
-            pd.DataFrame({'pnl': [1]}),
-            pd.DataFrame({'timestamp': [pd.Timestamp('2024-01-01')], 'equity': [100]})
-        )
-
-    monkeypatch.setattr('nicegold_v5.backtester.run_backtest', fake_run_backtest)
-    monkeypatch.setattr('nicegold_v5.utils.print_qa_summary', lambda *args, **kwargs: {})
-    monkeypatch.setattr('nicegold_v5.utils.create_summary_dict', lambda *args, **kwargs: {})
-    monkeypatch.setattr('nicegold_v5.utils.export_chatgpt_ready_logs', lambda *args, **kwargs: print('Export Completed'))
-    main.welcome()
-    output = capsys.readouterr().out
-    assert "Backtest จาก Signal" in output
-    assert "Export Completed" in output
-
-
-def test_manual_backtest_diagnostic(monkeypatch, capsys, tmp_path):
-    inputs = iter(['4'])
-    monkeypatch.setattr(builtins, "input", lambda prompt='': next(inputs))
-    main = importlib.import_module('main')
-    monkeypatch.setattr(main, "TRADE_DIR", str(tmp_path))
-    monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
-        'timestamp': pd.date_range('2024-01-01', periods=10, freq='h'),
-        'open': [1]*10,
-        'high': [1]*10,
-        'low': [1]*10,
-        'close': [1]*10,
-    }))
-
-    monkeypatch.setattr(
-        'nicegold_v5.entry.generate_signals_profit_v10',
-        lambda df, config=None: df.assign(entry_signal='sell'),
-    )
-
-    monkeypatch.setattr(
-        'nicegold_v5.backtester.run_backtest',
-        lambda df: (
-            pd.DataFrame({'pnl': [1]}),
-            pd.DataFrame({'timestamp': [pd.Timestamp('2024-01-01')], 'equity': [100]})
-        ),
-    )
-    monkeypatch.setattr('nicegold_v5.utils.print_qa_summary', lambda *a, **kw: {})
-    monkeypatch.setattr('nicegold_v5.utils.create_summary_dict', lambda *a, **kw: {})
-    monkeypatch.setattr('nicegold_v5.utils.export_chatgpt_ready_logs', lambda *a, **kw: None)
-
-    main.welcome()
-    output = capsys.readouterr().out
-    assert "Injecting Profit Config" in output
-
-def test_tp1_tp2_menu(monkeypatch, capsys, tmp_path):
-    inputs = iter(['6'])
-    monkeypatch.setattr(builtins, "input", lambda prompt='': next(inputs))
+def test_autorun_simulate(monkeypatch, capsys, tmp_path):
     main = importlib.import_module('main')
     monkeypatch.setattr(main, "TRADE_DIR", str(tmp_path))
     monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
         'timestamp': pd.date_range('2024-01-01', periods=2, freq='h'),
-        'close': [100, 101],
-        'signal': ['long', 'long'],
-        'session': ['London', 'London'],
-        'rsi': [25, 30],
-        'pattern': ['inside_bar', 'inside_bar']
+        'close': [100, 101]
     }))
-    monkeypatch.setattr('nicegold_v5.entry.simulate_trades_with_tp', lambda df: ([{
-        'entry_price': 100,
-        'tp1_price': 105,
-        'tp2_price': 110,
-        'exit_price': 110,
-        'exit_reason': 'tp2'
-    }], []))
+    monkeypatch.setattr(
+        'nicegold_v5.entry.simulate_trades_with_tp',
+        lambda df: ([{'exit_reason': 'tp1'}], [])
+    )
+    monkeypatch.setattr(main, 'safe_calculate_net_change', lambda df: 5.0)
     main.welcome()
     output = capsys.readouterr().out
-    assert "QA Summary (TP1/TP2)" in output
-    assert "TP2 Triggered" in output
+    assert 'QA Summary (TP1/TP2)' in output
+    assert 'TP1 Triggered' in output
 
 
-def test_tp1_tp2_menu_string_timestamp(monkeypatch, capsys, tmp_path):
-    inputs = iter(['6'])
-    monkeypatch.setattr(builtins, "input", lambda prompt='': next(inputs))
+def test_autorun_string_timestamp(monkeypatch, capsys, tmp_path):
     main = importlib.import_module('main')
     monkeypatch.setattr(main, "TRADE_DIR", str(tmp_path))
     monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
         'timestamp': ['2024-01-01 00:00:00', '2024-01-01 01:00:00'],
-        'close': [100, 101],
-        'signal': ['long', 'long'],
-        'session': ['London', 'London'],
-        'rsi': [25, 30],
-        'pattern': ['inside_bar', 'inside_bar']
+        'close': [100, 101]
     }))
 
     def fake_simulate(df):
         assert pd.api.types.is_datetime64_any_dtype(df['timestamp'])
-        return ([{
-            'entry_price': 100,
-            'tp1_price': 105,
-            'tp2_price': 110,
-            'exit_price': 110,
-            'exit_reason': 'tp2'
-        }], [])
+        return ([{'exit_reason': 'tp2'}], [])
 
     monkeypatch.setattr('nicegold_v5.entry.simulate_trades_with_tp', fake_simulate)
+    monkeypatch.setattr(main, 'safe_calculate_net_change', lambda df: 7.0)
     main.welcome()
     output = capsys.readouterr().out
-    assert "TP2 Triggered" in output
+    assert 'TP2 Triggered' in output
+


### PR DESCRIPTION
## Notes
- ปรับเมนู welcome ให้รัน simulate_trades_with_tp อัตโนมัติ
- ปรับ unit test ใน test_cli ให้รองรับการทำงานใหม่
- อัปเดต AGENTS.md และ changelog.md ตามแพทช์

## Summary
- เพิ่มบล็อก `[Patch v11.6]` ใน `welcome()` เพื่อรัน simulate_trades_with_tp และสรุปผล TP1/TP2 ทันที
- ปรับชุดทดสอบ CLI ให้ตรวจสอบการทำงานแบบอัตโนมัติ

## Testing
- `pytest -q`