### PR TITLE
Add fail-proof TP1/TP2 simulation

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -337,3 +337,5 @@
 - ลบไฟล์ m.ainmain.py และตัวอย่าง XAUUSD_M1.csv ที่ไม่ได้ใช้
 ### 2025-09-07
 - ปรับ welcome ให้รัน simulate_trades_with_tp อัตโนมัติเมื่อเริ่มต้น (Patch v11.6)
+### 2025-09-08
+- ปรับ welcome ให้ตรวจสอบคอลัมน์และสร้างสัญญาณอัตโนมัติ พร้อม progress bar และ RAM optimization (Patch v11.7)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -313,3 +313,5 @@
 - ลบไฟล์ที่ไม่ได้ใช้ m.ainmain.py และ XAUUSD_M1.csv
 ## 2025-09-07
 - welcome() รัน simulate_trades_with_tp อัตโนมัติ (Patch v11.6)
+## 2025-09-08
+- ปรับ welcome() ให้ตรวจสอบ timestamp, entry_signal, entry_time และสร้างสัญญาณอัตโนมัติ (Patch v11.7)


### PR DESCRIPTION
## Summary
- improve `welcome` to validate timestamp, entry columns and auto-generate signals
- add progress bars and RAM optimization during TP1/TP2 simulation
- update unit tests for new behaviour and add negative case
- document patch v11.7 in AGENTS and changelog

## Testing
- `pytest -q`