### PR TITLE
Fix timestamp warning in welcome

### DIFF
--- a/main.py
+++ b/main.py
@@ -253,7 +253,9 @@ def welcome():
     print("📊 [Patch v11.7] เริ่ม Fail-Proof TP1/TP2 Simulation...")
     df = load_csv_safe(M1_PATH)
     show_progress_bar("🧼 แปลง timestamp", steps=1)
-    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+    df["timestamp"] = pd.to_datetime(
+        df["timestamp"], format=DATETIME_FORMAT, errors="coerce"
+    )
     df = df.dropna(subset=["timestamp"])
     df = df.sort_values("timestamp")
 

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -341,3 +341,6 @@
 - ปรับ welcome ให้ตรวจสอบคอลัมน์และสร้างสัญญาณอัตโนมัติ พร้อม progress bar และ RAM optimization (Patch v11.7)
 ### 2025-09-09
 - เพิ่ม fallback กลยุทธ์ RELAX_CONFIG_Q3 ใน main.py เมื่อไม่มีสัญญาณ (Patch v11.8)
+
+### 2025-09-10
+- ระบุ DATETIME_FORMAT ในขั้นตอนแปลง timestamp ใน welcome() และเพิ่ม unit test ไม่เกิดคำเตือน

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -317,3 +317,6 @@
 - ปรับ welcome() ให้ตรวจสอบ timestamp, entry_signal, entry_time และสร้างสัญญาณอัตโนมัติ (Patch v11.7)
 ## 2025-09-09
 - เพิ่ม RELAX_CONFIG_Q3 และ fallback ใน main.py หากสัญญาณถูกบล็อกทั้งหมด (Patch v11.8)
+
+## 2025-09-10
+- ระบุ DATETIME_FORMAT ในขั้นตอนแปลง timestamp ใน welcome() และเพิ่มชุดทดสอบตรวจสอบคำเตือน

--- a/nicegold_v5/tests/test_patch_l_datetime_warning.py
+++ b/nicegold_v5/tests/test_patch_l_datetime_warning.py
@@ -1,0 +1,12 @@
+import pandas as pd
+import warnings
+import importlib
+
+def test_no_datetime_warning():
+    main = importlib.import_module('main')
+    df = pd.DataFrame({'timestamp': ['2025-01-01 00:00:00', '2025-01-01 01:00:00']})
+    with warnings.catch_warnings(record=True) as w:
+        df['timestamp'] = pd.to_datetime(
+            df['timestamp'], format=main.DATETIME_FORMAT, errors='coerce'
+        )
+    assert len(w) == 0


### PR DESCRIPTION
## Summary
- parse timestamps in `welcome` using `DATETIME_FORMAT`
- add regression test ensuring no parsing warnings
- update agent log and changelog

## Testing
- `pytest -q`