### PR TITLE
Fix entry tier calculation for small data

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -345,3 +345,5 @@
 ### 2025-09-10
 - ระบุ DATETIME_FORMAT ในขั้นตอนแปลง timestamp ใน welcome() และเพิ่ม unit test ไม่เกิดคำเตือน
 - แก้คำเตือน timestamp และ fallback ใน welcome() (Patch v11.9)
+### 2025-09-11
+- แก้ ValueError ใน generate_signals_v8_0 เมื่อข้อมูลมีน้อยกว่า 3 แถว กำหนด entry_tier="C" (Patch v11.9.1)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -321,3 +321,5 @@
 ## 2025-09-10
 - ระบุ DATETIME_FORMAT ในขั้นตอนแปลง timestamp ใน welcome() และเพิ่มชุดทดสอบตรวจสอบคำเตือน
 - แก้คำเตือน fallback datetime ใน welcome() และเพิ่มข้อความแจ้งเตือนใหม่ (Patch v11.9)
+## 2025-09-11
+- แก้บั๊ก qcut ใน generate_signals_v8_0 เมื่อจำนวนแถวน้อยกว่า 3 ทำให้เกิด ValueError (Patch v11.9.1)

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -156,9 +156,16 @@ def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.Da
     df.loc[df["entry_score"] > 4.0, "risk_level"] = "high"
 
     # --- Entry Tier (Quantile Classifier) ---
-    df["entry_tier"] = pd.qcut(
-        df["entry_score"].rank(method="first"), q=3, labels=["C", "B", "A"], duplicates="drop"
-    )
+    ranks = df["entry_score"].rank(method="first")
+    try:
+        if ranks.notna().sum() >= 3:
+            df["entry_tier"] = pd.qcut(
+                ranks, q=3, labels=["C", "B", "A"], duplicates="drop"
+            )
+        else:
+            raise ValueError("insufficient data")
+    except ValueError:
+        df["entry_tier"] = "C"
     df["confirm_zone"] = (
         (df["gain_z"] > 0.0)
         & (df["ema_slope"] > 0.02)

--- a/nicegold_v5/tests/test_entry_tier_bugfix.py
+++ b/nicegold_v5/tests/test_entry_tier_bugfix.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from nicegold_v5.entry import generate_signals_v8_0
+
+
+def test_entry_tier_handles_small_df():
+    df = pd.DataFrame({
+        'timestamp': pd.date_range('2025-01-01', periods=1, freq='min'),
+        'open': [1],
+        'high': [1],
+        'low': [1],
+        'close': [1],
+        'volume': [1],
+    })
+    out = generate_signals_v8_0(df)
+    assert 'entry_tier' in out.columns
+    assert out['entry_tier'].iloc[0] == 'C'


### PR DESCRIPTION
## Summary
- handle small datasets in `generate_signals_v8_0` when computing `entry_tier`
- add regression test for the bug
- update docs

## Testing
- `pytest -q`