### PR TITLE
Add data precheck before signal generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -259,6 +259,9 @@ def welcome():
     df = df.dropna(subset=["timestamp"])
     df = df.sort_values("timestamp")
 
+    from nicegold_v5.entry import validate_indicator_inputs
+    validate_indicator_inputs(df)
+
     show_progress_bar("⚙️ ตรวจสอบสัญญาณ", steps=1)
     if "entry_signal" not in df.columns:
         print("[Patch] 🧠 Auto-generating signals using v11 config...")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -359,3 +359,5 @@
 - แก้บั๊ก pandas apply คืนค่า DataFrame เมื่อไม่มีแถว ทำให้ assign entry_blocked_reason ล้มเหลว (Patch v11.9.6)
 ### 2025-09-17
 - เพิ่ม diagnostic fallback ใน welcome() หาก RELAX_CONFIG_Q3 ยังล้มเหลว (Patch v11.9.7)
+### 2025-09-18
+- เพิ่มฟังก์ชัน validate_indicator_inputs และเรียกใช้ใน main.py เพื่อตรวจสอบข้อมูลก่อนสร้างสัญญาณ (Patch v11.9.9)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -335,3 +335,5 @@
 - แก้บั๊ก assign entry_blocked_reason ล้มเหลวเมื่อ DataFrame ว่าง (Patch v11.9.6)
 ## 2025-09-17
 - ปรับ welcome() ให้มี diagnostic fallback เมื่อ RELAX_CONFIG_Q3 ยังไม่สร้างสัญญาณ (Patch v11.9.7)
+## 2025-09-18
+- เพิ่ม validate_indicator_inputs สำหรับตรวจสอบคอลัมน์และจำนวนแถว และเรียกใช้ใน welcome() (Patch v11.9.9)

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -73,6 +73,24 @@ def rsi(series: pd.Series, period: int = 14) -> pd.Series:
     return 100 - (100 / (1 + rs))
 
 
+def validate_indicator_inputs(df: pd.DataFrame, required_cols: list[str] | None = None, min_rows: int = 500) -> None:
+    """ตรวจสอบความพร้อมของข้อมูลก่อน generate_signal"""
+    if required_cols is None:
+        required_cols = ["close", "high", "low", "volume"]
+
+    missing_cols = [col for col in required_cols if col not in df.columns]
+    if missing_cols:
+        raise RuntimeError(f"[Patch v11.9.9] ❌ ขาดคอลัมน์จำเป็น: {missing_cols}")
+
+    row_count = df[required_cols].dropna().shape[0]
+    if row_count < min_rows:
+        raise RuntimeError(
+            f"[Patch v11.9.9] ❌ ข้อมูลมีเพียง {row_count} row ที่ใช้ได้ (ต้องการ ≥ {min_rows})"
+        )
+
+    print(f"[Patch v11.9.9] ✅ ตรวจผ่าน: มีข้อมูลพร้อมใช้งาน {row_count} row")
+
+
 def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:
     """ใช้ logic sniper + TP1/TSL แบบล่าสุด (Patch v8.0)."""
     df = df.copy()

--- a/nicegold_v5/tests/test_cli.py
+++ b/nicegold_v5/tests/test_cli.py
@@ -9,8 +9,13 @@ def test_autorun_simulate(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
         'timestamp': pd.date_range('2024-01-01', periods=2, freq='h'),
         'entry_signal': ['long', 'short'],
-        'entry_time': pd.date_range('2024-01-01', periods=2, freq='h')
+        'entry_time': pd.date_range('2024-01-01', periods=2, freq='h'),
+        'close': [1, 1],
+        'high': [1, 1],
+        'low': [1, 1],
+        'volume': [1, 1],
     }))
+    monkeypatch.setattr('nicegold_v5.entry.validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
     monkeypatch.setattr(
         'nicegold_v5.entry.simulate_trades_with_tp',
         lambda df: ([{'exit_reason': 'tp1'}], [])
@@ -28,12 +33,17 @@ def test_autorun_string_timestamp(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
         'timestamp': ['2024-01-01 00:00:00', '2024-01-01 01:00:00'],
         'entry_signal': ['long', 'short'],
-        'entry_time': ['2024-01-01 00:00:00', '2024-01-01 01:00:00']
+        'entry_time': ['2024-01-01 00:00:00', '2024-01-01 01:00:00'],
+        'close': [1, 1],
+        'high': [1, 1],
+        'low': [1, 1],
+        'volume': [1, 1],
     }))
 
     def fake_simulate(df):
         assert pd.api.types.is_datetime64_any_dtype(df['timestamp'])
         return ([{'exit_reason': 'tp2'}], [])
+    monkeypatch.setattr('nicegold_v5.entry.validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
 
     monkeypatch.setattr('nicegold_v5.entry.simulate_trades_with_tp', fake_simulate)
     monkeypatch.setattr(main, 'safe_calculate_net_change', lambda df: 7.0)
@@ -47,8 +57,13 @@ def test_autorun_missing_entry_time(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "TRADE_DIR", str(tmp_path))
     monkeypatch.setattr(main, "load_csv_safe", lambda path: pd.DataFrame({
         'timestamp': pd.date_range('2024-01-01', periods=1, freq='h'),
-        'entry_signal': ['long']
+        'entry_signal': ['long'],
+        'close': [1],
+        'high': [1],
+        'low': [1],
+        'volume': [1],
     }))
+    monkeypatch.setattr('nicegold_v5.entry.validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
 
     monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None: df)
     with pytest.raises(ValueError):
@@ -66,8 +81,13 @@ def test_autorun_relax_fallback(monkeypatch, capsys, tmp_path):
         lambda path: pd.DataFrame({
             'timestamp': pd.date_range('2024-01-01', periods=2, freq='h'),
             'entry_time': pd.date_range('2024-01-01', periods=2, freq='h'),
+            'close': [1, 1],
+            'high': [1, 1],
+            'low': [1, 1],
+            'volume': [1, 1],
         })
     )
+    monkeypatch.setattr('nicegold_v5.entry.validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
 
     def fake_generate(df, config=None):
         if config == main.SNIPER_CONFIG_Q3_TUNED:
@@ -100,8 +120,13 @@ def test_autorun_diagnostic_fallback(monkeypatch, capsys, tmp_path):
         lambda path: pd.DataFrame({
             'timestamp': pd.date_range('2024-01-01', periods=2, freq='h'),
             'entry_time': pd.date_range('2024-01-01', periods=2, freq='h'),
+            'close': [1, 1],
+            'high': [1, 1],
+            'low': [1, 1],
+            'volume': [1, 1],
         })
     )
+    monkeypatch.setattr("nicegold_v5.entry.validate_indicator_inputs", lambda df, required_cols=None, min_rows=500: None)
 
     from nicegold_v5 import config as cfg
 

--- a/nicegold_v5/tests/test_patch_o_validate_inputs.py
+++ b/nicegold_v5/tests/test_patch_o_validate_inputs.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import pytest
+from nicegold_v5.entry import validate_indicator_inputs
+
+
+def test_validate_inputs_missing_column():
+    df = pd.DataFrame({'close': [1, 2], 'high': [1, 2], 'low': [1, 2]})
+    with pytest.raises(RuntimeError):
+        validate_indicator_inputs(df)
+
+
+def test_validate_inputs_min_rows():
+    df = pd.DataFrame({'close': [1, 2], 'high': [1, 2], 'low': [1, 2], 'volume': [1, 2]})
+    with pytest.raises(RuntimeError):
+        validate_indicator_inputs(df, min_rows=5)
+
+
+def test_validate_inputs_pass(capsys):
+    df = pd.DataFrame({'close': range(5), 'high': range(5), 'low': range(5), 'volume': range(5)})
+    validate_indicator_inputs(df, min_rows=5)
+    assert '✅ ตรวจผ่าน' in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add `validate_indicator_inputs` helper to check columns and row count
- run the check in `welcome()` before generating signals
- update CLI tests to mock the new validation
- record patch v11.9.9 in AGENTS and changelog
- include unit tests for the new validation logic

## Testing
- `pytest -q`