### PR TITLE
Patch v11.9.14: sanitize clean backtest

### DIFF
--- a/main.py
+++ b/main.py
@@ -160,13 +160,17 @@ def load_csv_safe(path, lowercase=True):
 def run_clean_backtest(df: pd.DataFrame) -> pd.DataFrame:
     """Run backtest with cleaned signals and real exit logic."""
     df = df.copy()
+
+    # Ensure timestamp is datetime BEFORE signal generation
+    df["timestamp"] = pd.to_datetime(df["timestamp"], format=DATETIME_FORMAT, errors="coerce")
+
     from nicegold_v5.config import RELAX_CONFIG_Q3
     df = generate_signals(df, config=SNIPER_CONFIG_Q3_TUNED)
-    if df["entry_signal"].isnull().mean() == 1.0:
-        print("[Patch v11.9.13] ❗ ไม่พบสัญญาณใน Q3_TUNED – ใช้ fallback RELAX_CONFIG_Q3")
+    if "entry_signal" not in df.columns or df["entry_signal"].isnull().mean() == 1.0:
+        print("[Patch v11.9.14] ❗ ไม่พบสัญญาณใน Q3_TUNED – ใช้ fallback RELAX_CONFIG_Q3")
         df = generate_signals(df, config=RELAX_CONFIG_Q3)
 
-    print(f"[Patch v11.9.13] ✅ Entry Signal Coverage: {(df['entry_signal'].notna().mean() * 100):.2f}%")
+    print(f"[Patch v11.9.14] ✅ Entry Signal Coverage: {(df['entry_signal'].notna().mean() * 100):.2f}%")
 
     # Ensure timestamps are valid and use them for entry_time
     df["timestamp"] = pd.to_datetime(df["timestamp"], format=DATETIME_FORMAT)

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -371,3 +371,6 @@
 - ปรับปรุง `validate_indicator_inputs` ให้แทนค่า inf/-inf ด้วย NaN และแสดงตัวอย่างข้อมูลเมื่อจำนวนน้อย (Patch v11.9.11)
 ### 2025-09-22
 - ปรับ `run_clean_backtest` ให้ fallback ไปยัง RELAX_CONFIG_Q3 หาก Q3_TUNED ไม่พบสัญญาณ พร้อมแสดงเปอร์เซ็นต์สัญญาณ (Patch v11.9.13)
+
+### 2025-09-23
+- ปรับ run_clean_backtest แปลง timestamp ก่อนสร้างสัญญาณและเช็คคอลัมน์ entry_signal (Patch v11.9.14)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -346,3 +346,5 @@
 - ปรับปรุง validate_indicator_inputs แทนค่า inf/-inf ด้วย NaN และแสดง preview เมื่อข้อมูลไม่ครบ (Patch v11.9.11)
 ## 2025-09-22
 - ปรับ run_clean_backtest ให้ fallback ไปยัง RELAX_CONFIG_Q3 เมื่อไม่มีสัญญาณและพิมพ์ Coverage (Patch v11.9.13)
+## 2025-09-23
+- ปรับ run_clean_backtest แปลง timestamp ก่อนสร้างสัญญาณ ตรวจสอบคอลัมน์ entry_signal และพิมพ์ Coverage (Patch v11.9.14)


### PR DESCRIPTION
## Summary
- convert timestamp to datetime prior to signal generation in `run_clean_backtest`
- add fallback check for missing `entry_signal` column
- update Agent log and changelog

## Testing
- `pytest -q`