### PR TITLE
Patch v11.9.15: sanitize numbers with commas

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -374,3 +374,5 @@
 
 ### 2025-09-23
 - ปรับ run_clean_backtest แปลง timestamp ก่อนสร้างสัญญาณและเช็คคอลัมน์ entry_signal (Patch v11.9.14)
+### 2025-09-24
+- ปรับ sanitize_price_columns ให้รองรับตัวเลขมี comma และเว้นวรรค (Patch v11.9.15)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -348,3 +348,5 @@
 - ปรับ run_clean_backtest ให้ fallback ไปยัง RELAX_CONFIG_Q3 เมื่อไม่มีสัญญาณและพิมพ์ Coverage (Patch v11.9.13)
 ## 2025-09-23
 - ปรับ run_clean_backtest แปลง timestamp ก่อนสร้างสัญญาณ ตรวจสอบคอลัมน์ entry_signal และพิมพ์ Coverage (Patch v11.9.14)
+## 2025-09-24
+- ปรับ sanitize_price_columns ให้รองรับตัวเลขมี comma และเว้นวรรค (Patch v11.9.15)

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -104,9 +104,11 @@ def sanitize_price_columns(df: pd.DataFrame) -> pd.DataFrame:
     """แปลงคอลัมน์ราคาทั้งหมดให้เป็น float และ log รายงาน"""
     for col in ["close", "high", "low", "open", "volume"]:
         if col in df.columns:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
+            series = df[col].astype(str).str.replace(",", "", regex=False).str.strip()
+            df[col] = pd.to_numeric(series, errors="coerce")
+
     missing = df[["close", "high", "low", "volume"]].isnull().sum()
-    print("[Patch v11.9.10] 🧼 Sanitize Columns:")
+    print("[Patch v11.9.15] 🧼 Sanitize Columns:")
     for col, count in missing.items():
         print(f"   ▸ {col}: {count} NaN")
     return df

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -819,6 +819,19 @@ def test_sanitize_nan_count(capsys):
     log = capsys.readouterr().out
     assert 'close: 1 NaN' in log
 
+
+def test_sanitize_handle_commas():
+    df = pd.DataFrame({
+        'close': ['1,000', '2,000'],
+        'high': ['3,000', '4,000'],
+        'low': ['5,000', '6,000'],
+        'open': ['7,000', '8,000'],
+        'volume': ['9,000', '10,000'],
+    })
+    out = sanitize_price_columns(df)
+    assert out['close'].iloc[0] == 1000.0
+    assert out['volume'].iloc[1] == 10000.0
+
 import pandas as pd
 from nicegold_v5.entry import (
     apply_tp_logic,


### PR DESCRIPTION
## Summary
- enhance `sanitize_price_columns` to strip commas and whitespace
- add unit test for comma separated numbers
- update AGENTS and changelog for v11.9.15

## Testing
- `pytest -q`