### PR TITLE
Patch v11.9.16: sanitize & validate clean backtest

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -376,3 +376,5 @@
 - ปรับ run_clean_backtest แปลง timestamp ก่อนสร้างสัญญาณและเช็คคอลัมน์ entry_signal (Patch v11.9.14)
 ### 2025-09-24
 - ปรับ sanitize_price_columns ให้รองรับตัวเลขมี comma และเว้นวรรค (Patch v11.9.15)
+### 2025-09-25
+- ปรับ run_clean_backtest ให้ sanitize ข้อมูลและ validate ก่อนสร้างสัญญาณ พร้อม log coverage (Patch v11.9.16)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -350,3 +350,5 @@
 - ปรับ run_clean_backtest แปลง timestamp ก่อนสร้างสัญญาณ ตรวจสอบคอลัมน์ entry_signal และพิมพ์ Coverage (Patch v11.9.14)
 ## 2025-09-24
 - ปรับ sanitize_price_columns ให้รองรับตัวเลขมี comma และเว้นวรรค (Patch v11.9.15)
+## 2025-09-25
+- ปรับ run_clean_backtest แปลง timestamp และ sanitize ก่อน validate พร้อมพิมพ์ Coverage (Patch v11.9.16)

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -107,8 +107,9 @@ def sanitize_price_columns(df: pd.DataFrame) -> pd.DataFrame:
             series = df[col].astype(str).str.replace(",", "", regex=False).str.strip()
             df[col] = pd.to_numeric(series, errors="coerce")
 
-    missing = df[["close", "high", "low", "volume"]].isnull().sum()
-    print("[Patch v11.9.15] 🧼 Sanitize Columns:")
+    cols_to_check = [c for c in ["close", "high", "low", "volume"] if c in df.columns]
+    missing = df[cols_to_check].isnull().sum()
+    print("[Patch v11.9.16] 🧼 Sanitize Columns:")
     for col, count in missing.items():
         print(f"   ▸ {col}: {count} NaN")
     return df

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -446,6 +446,7 @@ def test_run_clean_backtest(monkeypatch, tmp_path):
         'high': [1]*5,
         'low': [1]*5,
         'close': [1]*5,
+        'volume': [100]*5,
     })
 
     monkeypatch.setattr(main, 'TRADE_DIR', str(tmp_path))
@@ -469,6 +470,7 @@ def test_run_clean_backtest_fallback(monkeypatch, capsys, tmp_path):
         'high': [1, 1],
         'low': [1, 1],
         'close': [1, 1],
+        'volume': [100, 100],
     })
 
     sentinel = {'relax': True}


### PR DESCRIPTION
## Summary
- sanitize and validate data before generating signals in `run_clean_backtest`
- make `sanitize_price_columns` handle missing columns
- update unit tests for added volume column
- document patch v11.9.16

## Testing
- `pytest -q`