### PR TITLE
เพิ่ม parse_timestamp_safe และปรับ timestamp

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,11 @@ from nicegold_v5.config import (
     RELAX_CONFIG_Q3,
 )
 from nicegold_v5.qa import run_qa_guard, auto_qa_after_backtest
-from nicegold_v5.utils import safe_calculate_net_change, convert_thai_datetime
+from nicegold_v5.utils import (
+    safe_calculate_net_change,
+    convert_thai_datetime,
+    parse_timestamp_safe,
+)
 # User-provided custom instructions
 # *สนทนาภาษาไทยเท่านั้น
 
@@ -166,7 +170,7 @@ def run_clean_backtest(df: pd.DataFrame) -> pd.DataFrame:
     # ✅ [Patch v11.9.18] รองรับ Date พ.ศ. ก่อนแปลง timestamp
     df = convert_thai_datetime(df)
     # ✅ [Patch v11.9.16] – Convert timestamp and sanitize before validation
-    df["timestamp"] = pd.to_datetime(df["timestamp"], format=DATETIME_FORMAT, errors="coerce")
+    df["timestamp"] = parse_timestamp_safe(df["timestamp"], DATETIME_FORMAT)
     df = df.dropna(subset=["timestamp"])
     df = df.sort_values("timestamp")
     df = sanitize_price_columns(df)
@@ -182,7 +186,7 @@ def run_clean_backtest(df: pd.DataFrame) -> pd.DataFrame:
     print(f"[Patch v11.9.16] ✅ Entry Signal Coverage: {signal_coverage:.2f}%")
 
     # Ensure timestamps are valid and use them for entry_time
-    df["timestamp"] = pd.to_datetime(df["timestamp"], format=DATETIME_FORMAT)
+    df["timestamp"] = parse_timestamp_safe(df["timestamp"], DATETIME_FORMAT)
     df["entry_time"] = df["timestamp"]
     df["signal_id"] = df["timestamp"].astype(str)
 
@@ -274,9 +278,7 @@ def welcome():
     # ✅ [Patch v11.9.18] รองรับ Date แบบพุทธศักราช
     df = convert_thai_datetime(df)
     show_progress_bar("🧼 แปลง timestamp", steps=1)
-    df["timestamp"] = pd.to_datetime(
-        df["timestamp"], format="%Y-%m-%d %H:%M:%S", errors="coerce"
-    )
+    df["timestamp"] = parse_timestamp_safe(df["timestamp"], DATETIME_FORMAT)
     df = df.dropna(subset=["timestamp"])
     df = df.sort_values("timestamp")
 
@@ -390,9 +392,7 @@ def welcome():
         df = convert_thai_datetime(df)
 
         # [Patch] Apply full datetime and signal generation
-        df["timestamp"] = pd.to_datetime(
-            df["timestamp"], format="%Y-%m-%d %H:%M:%S", errors="coerce"
-        )
+        df["timestamp"] = parse_timestamp_safe(df["timestamp"], DATETIME_FORMAT)
         df = df.sort_values("timestamp")
 
         from nicegold_v5.entry import (
@@ -453,9 +453,7 @@ def welcome():
         # ✅ [Patch v11.9.18] รองรับ Date แบบพุทธศักราช
         df = convert_thai_datetime(df)
 
-        df["timestamp"] = pd.to_datetime(
-            df["timestamp"], format=DATETIME_FORMAT, errors="coerce"
-        )
+        df["timestamp"] = parse_timestamp_safe(df["timestamp"], DATETIME_FORMAT)
         df = df.sort_values("timestamp")
 
         from nicegold_v5.entry import simulate_trades_with_tp  # ← Patch v11.2 logic
@@ -495,9 +493,7 @@ if __name__ == "__main__":
         df = convert_thai_datetime(df)
 
         df.dropna(subset=["timestamp"], inplace=True)
-        df["timestamp"] = pd.to_datetime(
-            df["timestamp"], format=DATETIME_FORMAT, errors="coerce"
-        )
+        df["timestamp"] = parse_timestamp_safe(df["timestamp"], DATETIME_FORMAT)
         df = df.dropna(subset=["timestamp"])
         run_clean_backtest(df)
         print("✅ Done: Clean Backtest Completed")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -380,3 +380,5 @@
 - ปรับ run_clean_backtest ให้ sanitize ข้อมูลและ validate ก่อนสร้างสัญญาณ พร้อม log coverage (Patch v11.9.16)
 ### 2025-09-26
 - เพิ่ม convert_thai_datetime รองรับ Date+Timestamp แบบ พ.ศ. และเรียกใช้ใน main.py (Patch v11.9.18)
+### 2025-09-27
+- เพิ่มฟังก์ชัน `parse_timestamp_safe` แปลงเวลาพร้อม fallback หากรูปแบบไม่ตรง และใช้งานใน main.py (Patch v11.9.19)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -355,3 +355,5 @@
 
 ## 2025-09-26
 - เพิ่ม convert_thai_datetime รองรับ Date+Timestamp แบบ พ.ศ. และเรียกใช้ใน main.py (Patch v11.9.18)
+## 2025-09-27
+- เพิ่มฟังก์ชัน `parse_timestamp_safe` เพื่อแปลง timestamp อย่างยืดหยุ่นและ fallback หากรูปแบบไม่ตรง พร้อมปรับ main.py ใช้ฟังก์ชันนี้ (Patch v11.9.19)

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -929,3 +929,16 @@ def test_simulate_trades_with_tp():
     trade = trades[0]
     assert trade['tp1_price'] > trade['entry_price']
     assert trade['tp2_price'] > trade['tp1_price']
+
+
+def test_parse_timestamp_safe_fallback(capsys):
+    from nicegold_v5.utils import parse_timestamp_safe
+
+    series = pd.Series([
+        'bad',
+        '2025-01-01 00:00:00',
+        '2025/01/01 01:00:00'
+    ])
+    result = parse_timestamp_safe(series, '%Y-%m-%d %H:%M:%S')
+    assert result.notna().sum() == 2
+    assert 'retry without format' in capsys.readouterr().out.lower()

--- a/nicegold_v5/utils.py
+++ b/nicegold_v5/utils.py
@@ -275,6 +275,18 @@ def convert_thai_datetime(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def parse_timestamp_safe(series: pd.Series, fmt: str) -> pd.Series:
+    """Parse timestamp with a fallback when the strict format fails."""
+    ts = pd.to_datetime(series, format=fmt, errors="coerce")
+    success_ratio = ts.notna().mean()
+    if success_ratio < 0.5:
+        print(
+            f"[Patch v11.9.19] ⚠️ parsed only {success_ratio:.0%} with format {fmt} – retry without format"
+        )
+        ts = pd.to_datetime(series, errors="coerce")
+    return ts
+
+
 def simulate_tp_exit(
     df_trades: pd.DataFrame,
     df_m1: pd.DataFrame,


### PR DESCRIPTION
## Notes
- เพิ่มฟังก์ชัน `parse_timestamp_safe` ใน `utils.py` ใช้ fallback หากแปลงเวลาตามรูปแบบไม่ได้
- ปรับ `main.py` ให้เรียกใช้ฟังก์ชันนี้ทุกจุดที่แปลง `timestamp`
- เพิ่มชุดทดสอบ `test_parse_timestamp_safe_fallback`
- อัปเดต `AGENTS.md` และ `changelog.md`

## Testing
- `pytest -q`