### PR TITLE
Improve CSV loading fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,8 +91,8 @@ def run_csv_integrity_check():
     return True
 
 TRADE_DIR = "/content/drive/MyDrive/NICEGOLD/logs"
-M1_PATH = "/content/drive/MyDrive/NICEGOLD/XAUUSD_M1.csv"
-M15_PATH = "/content/drive/MyDrive/NICEGOLD/XAUUSD_M15.csv"
+M1_PATH = os.getenv("M1_PATH", "/content/drive/MyDrive/NICEGOLD/XAUUSD_M1.csv")
+M15_PATH = os.getenv("M15_PATH", "/content/drive/MyDrive/NICEGOLD/XAUUSD_M15.csv")
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 os.makedirs(TRADE_DIR, exist_ok=True)
 
@@ -148,6 +148,11 @@ def run_parallel_wfv(df: pd.DataFrame, features: list, label_col: str, n_folds: 
 
 
 def load_csv_safe(path, lowercase=True):
+    """Load CSV with fallback to local data directory."""
+    if not os.path.exists(path):
+        alt = os.path.join(os.path.dirname(__file__), "nicegold_v5", os.path.basename(path))
+        if os.path.exists(alt):
+            path = alt
     try:
         with tqdm(total=1, desc=f"📥 Loading {os.path.basename(path)}") as pbar:
             df = pd.read_csv(path, engine="python", on_bad_lines="skip")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -382,3 +382,6 @@
 - เพิ่ม convert_thai_datetime รองรับ Date+Timestamp แบบ พ.ศ. และเรียกใช้ใน main.py (Patch v11.9.18)
 ### 2025-09-27
 - เพิ่มฟังก์ชัน `parse_timestamp_safe` แปลงเวลาพร้อม fallback หากรูปแบบไม่ตรง และใช้งานใน main.py (Patch v11.9.19)
+### 2025-09-28
+- เพิ่ม fallback ใน `load_csv_safe` ให้ค้นหาไฟล์ในไดเรกทอรี `nicegold_v5` หาก path หลักไม่พบ
+- กำหนดตัวแปร M1_PATH/M15_PATH ให้ใช้ค่าใน environment ได้ (Patch v11.9.20)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -357,3 +357,5 @@
 - เพิ่ม convert_thai_datetime รองรับ Date+Timestamp แบบ พ.ศ. และเรียกใช้ใน main.py (Patch v11.9.18)
 ## 2025-09-27
 - เพิ่มฟังก์ชัน `parse_timestamp_safe` เพื่อแปลง timestamp อย่างยืดหยุ่นและ fallback หากรูปแบบไม่ตรง พร้อมปรับ main.py ใช้ฟังก์ชันนี้ (Patch v11.9.19)
+## 2025-09-28
+- ปรับ `load_csv_safe` ให้ค้นหาไฟล์ในไดเรกทอรี `nicegold_v5` เมื่อ path หลักไม่พบ และรองรับตัวแปรสภาพแวดล้อม `M1_PATH`/`M15_PATH` (Patch v11.9.20)

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -942,3 +942,11 @@ def test_parse_timestamp_safe_fallback(capsys):
     result = parse_timestamp_safe(series, '%Y-%m-%d %H:%M:%S')
     assert result.notna().sum() == 2
     assert 'retry without format' in capsys.readouterr().out.lower()
+
+
+def test_load_csv_safe_fallback():
+    import importlib
+    main = importlib.import_module('main')
+    path = '/invalid/path/XAUUSD_M1.csv'
+    df = main.load_csv_safe(path)
+    assert not df.empty


### PR DESCRIPTION
## Summary
- fallback CSV path to repo data directory when default path missing
- allow overriding M1_PATH and M15_PATH via environment
- add test for load_csv_safe fallback
- document new patch in AGENTS and changelog

## Testing
- `pytest -q`