### PR TITLE
[Patch v12.8.3] เพิ่ม Risk Metrics ใน simulate_trades_with_tp

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -413,3 +413,6 @@
 ### 2025-10-11
 - ปรับปรุง run_backtest ใช้การอ่านข้อมูลแบบ array ลดเวลา loop (Patch Perf-E)
 
+### 2025-10-12
+- เพิ่มกำไรสุทธิและ Risk Metrics ใน simulate_trades_with_tp และรองรับ Sell ครบระบบ (Patch v12.8.3)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -387,3 +387,6 @@
 ## 2025-10-11
 - ปรับปรุง run_backtest ให้ใช้ array แทน itertuples ลดคอขวด (Patch Perf-E)
 
+## 2025-10-12
+- เพิ่มกำไรสุทธิและ Risk Metrics ใน simulate_trades_with_tp และรองรับ Sell ครบระบบ (Patch v12.8.3)
+

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -978,7 +978,15 @@ def test_session_filter():
 
 def test_trade_log_fields():
     required = {
-        'tp1_price', 'tp2_price', 'mfe', 'duration_min', 'entry_tier', 'signal_name'
+        'tp1_price',
+        'tp2_price',
+        'mfe',
+        'duration_min',
+        'entry_tier',
+        'signal_name',
+        'pnl',  # [Patch v12.8.3]
+        'planned_risk',  # [Patch v12.8.3]
+        'r_multiple',  # [Patch v12.8.3]
     }
     assert required.issubset(set(trade_log_fields))
 
@@ -1010,6 +1018,9 @@ def test_simulate_trades_with_tp():
     assert trade['entry_tier'] == 'C'
     assert trade['signal_name'] == 'RSI_InsideBar'
     assert isinstance(trade['mfe'], float)
+    assert trade['pnl'] > 0  # [Patch v12.8.3]
+    assert trade['planned_risk'] == 0.5  # [Patch v12.8.3]
+    assert trade['r_multiple'] > 2.0  # [Patch v12.8.3]
 
 
 def test_parse_timestamp_safe_logs(capsys):


### PR DESCRIPTION
## Notes
- เพิ่มฟิลด์ risk metrics (pnl, planned_risk, r_multiple) และต้นทุนต่างๆ ใน `simulate_trades_with_tp`
- ปรับ `trade_log_fields` ให้รวมคอลัมน์ใหม่ทั้งหมด
- อัพเดต unit test ตรวจสอบฟิลด์และค่าใหม่
- อัพเดต `AGENTS.md` และ `changelog.md` ตามแพทช์ v12.8.3

## Testing
- `pytest -q`