### PR TITLE
Add sell entry signals

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -416,3 +416,6 @@
 ### 2025-10-12
 - เพิ่มกำไรสุทธิและ Risk Metrics ใน simulate_trades_with_tp และรองรับ Sell ครบระบบ (Patch v12.8.3)
 
+### 2025-10-13
+- ปรับ generate_entry_signal เพิ่มสัญญาณ SELL เช่น RSI70_InsideBar, QM_Bearish และ BearishEngulfing (Patch v12.9.0)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -390,3 +390,6 @@
 ## 2025-10-12
 - เพิ่มกำไรสุทธิและ Risk Metrics ใน simulate_trades_with_tp และรองรับ Sell ครบระบบ (Patch v12.8.3)
 
+## 2025-10-13
+- ปรับ generate_entry_signal เพิ่มสัญญาณ SELL RSI70_InsideBar, QM_Bearish และ BearishEngulfing (Patch v12.9.0)
+

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -18,12 +18,22 @@ def apply_tp_logic(entry_price: float, direction: str, rr1: float = 1.5, rr2: fl
 def generate_entry_signal(row: dict, log_list: list) -> str | None:
     """ระบุตำแหน่งเข้าเทรดและบันทึกลง log"""
     signal = None
+
+    # ✅ ฝั่ง BUY (เดิม)
     if row.get("rsi", 50) < 30 and row.get("pattern") == "inside_bar":
         signal = "RSI_InsideBar"
     elif row.get("pattern") == "qm":
         signal = "QM"
     elif row.get("pattern") == "fractal_v":
         signal = "FractalV"
+
+    # ✅ [Patch v12.9.0] เพิ่ม SELL SIGNAL ใหม่
+    elif row.get("rsi", 50) > 70 and row.get("pattern") == "inside_bar":
+        signal = "RSI70_InsideBar"
+    elif row.get("pattern") == "qm_bearish":
+        signal = "QM_Bearish"
+    elif row.get("pattern") == "bearish_engulfing":
+        signal = "BearishEngulfing"
 
     if ENABLE_SIGNAL_LOG:
         log_list.append(

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -969,6 +969,20 @@ def test_generate_entry_signal():
     assert logs and logs[0]['signal'] == 'RSI_InsideBar'
 
 
+def test_generate_entry_signal_sell():
+    logs = []
+    row = {
+        'rsi': 75,
+        'pattern': 'inside_bar',
+        'timestamp': pd.Timestamp('2025-01-01'),
+        'close': 100.0,
+        'session': 'London',
+    }
+    signal = generate_entry_signal(row, logs)
+    assert signal == 'RSI70_InsideBar'
+    assert logs and logs[0]['signal'] == 'RSI70_InsideBar'
+
+
 def test_session_filter():
     row_block = {'session': 'NY', 'ny_sl_count': 4}
     row_allow = {'session': 'NY', 'ny_sl_count': 1}


### PR DESCRIPTION
## Summary
- extend `generate_entry_signal` with sell patterns
- cover new behaviour in unit tests
- update docs and changelog

## Testing
- `pytest -q`