### PR TITLE
Fix performance bottleneck in run_parallel_wfv

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -419,3 +419,6 @@
 ### 2025-10-13
 - ปรับ generate_entry_signal เพิ่มสัญญาณ SELL เช่น RSI70_InsideBar, QM_Bearish และ BearishEngulfing (Patch v12.9.0)
 
+### 2025-10-14
+- ปรับ run_parallel_wfv ใช้ multiprocessing จริง พร้อม fallback หากล้มเหลว (Patch Perf-F)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -393,3 +393,6 @@
 ## 2025-10-13
 - ปรับ generate_entry_signal เพิ่มสัญญาณ SELL RSI70_InsideBar, QM_Bearish และ BearishEngulfing (Patch v12.9.0)
 
+## 2025-10-14
+- ปรับ run_parallel_wfv ใช้ multiprocessing จริง และ fallback แบบ sequential หากล้มเหลว (Patch Perf-F)
+


### PR DESCRIPTION
## Summary
- improve `_run_fold` to accept custom fold names
- use multiprocessing with spawn context in `run_parallel_wfv`
- update change log and agent instructions

## Testing
- `pytest -q`