### PR TITLE
Add sell signals and TP improvements

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -422,3 +422,7 @@
 ### 2025-10-14
 - ปรับ run_parallel_wfv ใช้ multiprocessing จริง พร้อม fallback หากล้มเหลว (Patch Perf-F)
 
+### 2025-10-15
+- เพิ่มตรรกะหยุด TP1 หาก entry_score สูงและ MFE มากใน simulate_trades_with_tp
+- ติดตั้งระบบ Breakeven และ Trailing SL แบบใหม่ (Patch v12.9.3-v12.9.4)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -396,3 +396,7 @@
 ## 2025-10-14
 - ปรับ run_parallel_wfv ใช้ multiprocessing จริง และ fallback แบบ sequential หากล้มเหลว (Patch Perf-F)
 
+## 2025-10-15
+- simulate_trades_with_tp ปรับ skip TP1 เมื่อ entry_score > 4.5 และ MFE > 3 (Patch v12.9.3)
+- เพิ่มตรรกะ Breakeven และ Trailing SL ภายใน simulate_trades_with_tp (Patch v12.9.4)
+


### PR DESCRIPTION
## Notes
- ปรับ generate_entry_signal เพิ่มเงื่อนไขขาลงและ fallback sell
- ปรับ simulate_trades_with_tp ให้ข้าม TP1 ในกรณีสัญญาณแรง และเพิ่มตรรกะ BE/TSL
- เพิ่มการทดสอบ unit test สำหรับสัญญาณใหม่และ logic ข้าม TP1
- อัพเดต AGENTS.md และ changelog.md

## Testing
- `pytest -q`