### PR TITLE
ปรับ Trailing SL แบบไดนามิก

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -426,3 +426,6 @@
 - เพิ่มตรรกะหยุด TP1 หาก entry_score สูงและ MFE มากใน simulate_trades_with_tp
 - ติดตั้งระบบ Breakeven และ Trailing SL แบบใหม่ (Patch v12.9.3-v12.9.4)
 
+### 2025-10-16
+- ปรับ BE/TSL ให้คำนวณ trailing stop แบบไดนามิกจากราคาในหน้าต่างและ ATR (Patch v12.9.6)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -400,3 +400,6 @@
 - simulate_trades_with_tp ปรับ skip TP1 เมื่อ entry_score > 4.5 และ MFE > 3 (Patch v12.9.3)
 - เพิ่มตรรกะ Breakeven และ Trailing SL ภายใน simulate_trades_with_tp (Patch v12.9.4)
 
+## 2025-10-16
+- simulate_trades_with_tp ปรับ BE/TSL แบบไดนามิกตามค่า ATR และราคาในหน้าต่าง (Patch v12.9.6)
+

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -1089,6 +1089,34 @@ def test_simulate_trades_with_tp_skip_tp1():
     assert trades[0]['exit_reason'] == 'tp2'
 
 
+def test_simulate_trades_with_tp_dynamic_tsl():
+    from nicegold_v5.entry import simulate_trades_with_tp
+
+    data = [
+        {
+            'timestamp': pd.Timestamp('2025-01-01 00:00:00'),
+            'close': 100.0,
+            'high': 105.0,
+            'low': 96.0,
+            'signal': 'long',
+            'session': 'London',
+            'rsi': 25,
+            'pattern': 'inside_bar',
+            'atr': 1.0,
+            'entry_score': 5.0,
+            'mfe': 4.0,
+        },
+        {'timestamp': pd.Timestamp('2025-01-01 00:10:00'), 'close': 106.0, 'high': 107.0, 'low': 96.0, 'session': 'NY', 'ny_sl_count': 4},
+        {'timestamp': pd.Timestamp('2025-01-01 00:20:00'), 'close': 110.0, 'high': 111.0, 'low': 101.0, 'session': 'NY', 'ny_sl_count': 4},
+        {'timestamp': pd.Timestamp('2025-01-01 00:30:00'), 'close': 108.0, 'high': 114.9, 'low': 107.0, 'session': 'NY', 'ny_sl_count': 4},
+        {'timestamp': pd.Timestamp('2025-01-01 00:40:00'), 'close': 114.0, 'high': 114.0, 'low': 110.0, 'session': 'NY', 'ny_sl_count': 4},
+    ]
+    df = pd.DataFrame(data)
+
+    trades, _ = simulate_trades_with_tp(df)
+    assert trades[0]['exit_reason'] == 'tsl_exit'
+
+
 def test_parse_timestamp_safe_logs(capsys):
     from nicegold_v5.utils import parse_timestamp_safe
 


### PR DESCRIPTION
## Summary
- ปรับคอมเมนต์ fallback sell
- ปิด TP1 อัตโนมัติหากไม้มีโอกาสทำ TP2 จริง
- เพิ่มระบบ Breakeven/Trailing SL แบบไดนามิก
- เพิ่มชุดทดสอบกรณี Trailing SL
- อัปเดต AGENTS และ changelog

## Testing
- `pytest -q`