### PR TITLE
Implement session-aware partial TP simulation

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -431,3 +431,6 @@
 ### 2025-10-17
 - เพิ่ม simulate_partial_tp_safe และปรับ should_exit รองรับ BE/TSL + BE Delay (Patch v12.1.x)
 
+### 2025-10-18
+- ปรับ simulate_partial_tp_safe ตรวจจับเซสชันอัตโนมัติและเปิด TSL หลัง TP1 (Patch v12.2.x)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -406,3 +406,7 @@
 ## 2025-10-17
 - เพิ่มฟังก์ชัน `simulate_partial_tp_safe` และปรับ `should_exit` ให้รองรับ BE/TSL แบบใหม่ (Patch v12.1.x)
 
+## 2025-10-18
+- ปรับปรุง `simulate_partial_tp_safe` ให้ตรวจเซสชันอัตโนมัติและเปิด Trailing SL หลัง TP1
+  (Patch v12.2.x)
+


### PR DESCRIPTION
## Summary
- auto-detect session by timestamp
- update partial TP logic to enable trailing SL after TP1
- record session in trades
- document patch v12.2.x in AGENTS and changelog

## Testing
- `pytest -q`