### PR TITLE
Fix simulate_partial_tp_safe import

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,9 @@
 
 import os
 import sys
-sys.path.append("/content/drive/MyDrive/NICEGOLD")  # Add project root to path
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.append(ROOT_DIR)
 
 import pandas as pd
 import gc
@@ -24,10 +26,10 @@ import numpy as np
 from nicegold_v5.utils import run_auto_wfv, split_by_session
 from nicegold_v5.entry import (
     generate_signals_v12_0 as generate_signals,
-    simulate_partial_tp_safe,  # [Patch v12.2.x]
     sanitize_price_columns,
     validate_indicator_inputs,
 )
+from nicegold_v5.exit import simulate_partial_tp_safe  # [Patch v12.2.x]
 from nicegold_v5.config import (
     SNIPER_CONFIG_PROFIT,
     SNIPER_CONFIG_Q3_TUNED,

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -438,3 +438,5 @@
 - เพิ่ม unit test สำหรับ detect_session_auto และ simulate_partial_tp_safe (Patch QA)
 ### 2025-10-20
 - ปรับ main.py ใช้ simulate_partial_tp_safe แทน simulate_trades_with_tp และบันทึก log เซสชัน
+### 2025-10-21
+- แก้บั๊ก import simulate_partial_tp_safe ใน main.py และเพิ่ม ROOT_DIR ใน sys.path

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -415,3 +415,7 @@
 - เพิ่ม unit test สำหรับตรวจสอบ session auto และการทำงานของ simulate_partial_tp_safe
 ## 2025-10-20
 - ปรับ main.py ใช้ simulate_partial_tp_safe แทน simulate_trades_with_tp และบันทึกข้อมูล exit/session
+
+## 2025-10-21
+- แก้บั๊ก ImportError เมื่อเรียก simulate_partial_tp_safe จาก main.py
+- ปรับ main.py ให้เพิ่ม path โฟลเดอร์อัตโนมัติด้วย ROOT_DIR


### PR DESCRIPTION
## Notes
- fixed ImportError by dynamically adding ROOT_DIR to sys.path
- import `simulate_partial_tp_safe` from `exit` module
- updated changelog and AGENTS instructions

## Testing
- `pytest -q`
- `python main.py`
