### PR TITLE
ปรับปรุง run_clean_backtest พร้อมส่งออก JSON

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -469,3 +469,8 @@
 - ย้าย sanitize ก่อน validate และย้าย fallback หลัง generate_signals
 - บันทึกไฟล์ `trades_v1239.csv` และอัปเดต import
 
+### 2025-10-29
+- เพิ่มการ export trade log และ config เป็น JSON ใน `run_clean_backtest`
+- บันทึก QA Summary ต่อไฟล์และแสดงผลสรุป TP1/TP2
+- เพิ่มตัวอย่างเมนู choice 7 ใน `welcome()` (คอมเมนต์ไว้)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -447,3 +447,8 @@
 - ย้าย sanitize ก่อน validate และขยับ fallback หลัง generate_signals
 - บันทึกผลเป็น `trades_v1239.csv` และแก้ import os
 
+## 2025-10-29
+- อัพเดต `run_clean_backtest` ให้ export trade log และ config เป็น JSON
+- สรุปผล QA ต่อไฟล์ `qa_summary_<ts>.json` และแสดงบนหน้าจอ
+- เพิ่มคอมเมนต์เมนู choice 7 สำหรับ CleanBacktest ใน `welcome()`
+


### PR DESCRIPTION
## Notes
- ปรับปรุง `run_clean_backtest` ให้รองรับข้อมูล Date/Timestamp แบบพุทธศักราชและตัวพิมพ์เล็ก
- เพิ่มการส่งออก trade log และ config เป็น JSON พร้อม QA summary
- เสริมคอมเมนต์เมนู choice 7 ใน `welcome()`
- อัปเดต `AGENTS.md` และ `changelog.md`

## Testing
- `pytest -q`