### PR TITLE
ปรับ trade log ใช้ entry_price ใน backtester

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -484,4 +484,6 @@
 - ปรับ welcome() ให้ใช้ trades ใน DataFrame และเพิ่มคอมเมนต์ Patch v15.7.1
 ### 2025-11-02
 - ปรับ simulate_partial_tp_safe ใช้ key 'entry_price' แทน 'entry' และเพิ่ม trade_entry (Patch v15.7.2)
+### 2025-11-03
+- ปรับ run_backtest ให้บันทึก entry_price และ exit_price ใน trade log (Patch v15.7.3)
 

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -227,8 +227,8 @@ def run_backtest(df: pd.DataFrame):
                 trade = {
                     "entry_time": open_trade["entry_time"],
                     "exit_time": ts,
-                    "entry": open_trade["entry"],
-                    "exit": price,
+                    "entry_price": open_trade["entry"],
+                    "exit_price": price,
                     "type": open_trade["type"],
                     "lot": partial_lot,
                     "pnl": partial_pnl - commission - spread_cost - slippage_cost,
@@ -263,8 +263,8 @@ def run_backtest(df: pd.DataFrame):
                     trade = {
                         "entry_time": open_trade["entry_time"],
                         "exit_time": ts,
-                        "entry": open_trade["entry"],
-                        "exit": price,
+                        "entry_price": open_trade["entry"],
+                        "exit_price": price,
                         "type": direction,
                         "lot": open_trade["lot"],
                         "pnl": pnl - commission - spread_cost - slippage_cost,
@@ -301,8 +301,8 @@ def run_backtest(df: pd.DataFrame):
                     trade = {
                         "entry_time": open_trade["entry_time"],
                         "exit_time": ts,
-                        "entry": open_trade["entry"],
-                        "exit": price,
+                        "entry_price": open_trade["entry"],
+                        "exit_price": price,
                         "type": direction,
                         "lot": open_trade["lot"],
                         "pnl": pnl - commission - spread_cost - slippage_cost,

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -462,4 +462,6 @@
 - ปรับ welcome() สร้าง trade_df จาก trades แทน logs และเพิ่มคอมเมนต์ (Patch v15.7.1)
 ## 2025-11-02
 - ปรับ simulate_partial_tp_safe ใช้คอลัมน์ entry_price แทน entry และเพิ่ม trade_entry (Patch v15.7.2)
+## 2025-11-03
+- ปรับ run_backtest ใช้คีย์ entry_price/exit_price ใน trade log (Patch v15.7.3)
 


### PR DESCRIPTION
## Summary
- refactor `run_backtest` ให้บันทึก `entry_price` และ `exit_price`
- อัปเดต AGENTS.md และ changelog

## Testing
- `pytest -q`