### PR TITLE
Improve fix_engine with profit-aware auto adjustments

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -502,3 +502,7 @@
 - เพิ่มฟังก์ชัน `generate_pattern_signals` ตรวจจับ Engulfing และ Inside Bar
 - เพิ่มการทดสอบ unit test สำหรับฟังก์ชันใหม่ (Patch v16.0.0)
 
+### 2025-11-08
+- ปรับปรุง `fix_engine.auto_fix_logic` ให้คำนวณ `net_pnl` และเปิด Dynamic TSL
+  อัตโนมัติเมื่อกำไรสุทธิเป็นลบ พร้อมเพิ่มเงื่อนไขขยาย SL และเพิ่ม hold time
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -479,3 +479,7 @@
 - เพิ่ม `generate_pattern_signals` สำหรับตรวจจับ Engulfing และ Inside Bar
 - อัปเดตชุดทดสอบรองรับฟังก์ชันใหม่ (Patch v16.0.0)
 
+## 2025-11-08
+- ปรับปรุง `fix_engine.auto_fix_logic` ตรวจจับกำไรสุทธิเป็นลบและปรับ RR/SL
+  อัตโนมัติ เพิ่มการใช้ Dynamic TSL และเวลา hold ขั้นต่ำ (Patch v16.1.0)
+


### PR DESCRIPTION
## Notes
- Updated `fix_engine.auto_fix_logic` to adjust RR and ATR dynamically when net PnL is negative.
- Added net PnL metrics in `run_self_diagnostic`.
- Updated AGENTS.md and changelog with latest patch entry.
- All tests pass (`pytest -q`).