### PR TITLE
Fix WFV open column fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -287,6 +287,17 @@ def run_clean_backtest(df: pd.DataFrame) -> pd.DataFrame:
     return trades_df
 
 def run_wfv_with_progress(df, features, label_col):
+    # [Patch vWFV.7] Fallback support for lowercase 'open' or only 'close'
+    if "Open" not in df.columns:
+        if "open" in df.columns:
+            df = df.rename(columns={"open": "Open"})
+            print("[Patch vWFV.7] 🛠️ rename 'open' → 'Open'")
+        elif "close" in df.columns:
+            df = df.copy()
+            df["Open"] = df["close"]
+            print("[Patch vWFV.7] 🛠️ create 'Open' from 'close'")
+        else:
+            raise ValueError("[Patch vWFV.7] ❌ Missing 'Open'/'open'/'close'")
     from nicegold_v5.utils import split_by_session
 
     logging.info("[TIME] run_wfv_with_progress(): Start")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -538,3 +538,5 @@
 
 ### 2025-11-21
 - ปรับ main.py เมนู 7 ใช้ฟังก์ชัน rsi แบบเวกเตอร์ ลดเวลา WFV (Patch vWFV.6)
+### 2025-11-22
+- แก้ run_wfv_with_progress รองรับคอลัมน์ 'open' หรือ 'close' เป็น 'Open' (Patch vWFV.7)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -517,3 +517,5 @@
 
 ## 2025-11-21
 - ปรับ main.py เมนู 7 ใช้ฟังก์ชัน rsi แบบเวกเตอร์ ลดเวลาคำนวณ WFV (Patch vWFV.6)
+## 2025-11-22
+- แก้ run_wfv_with_progress ให้ fallback คอลัมน์ 'Open' จาก 'open' หรือ 'close' (Patch vWFV.7)

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -446,6 +446,24 @@ def test_run_wfv_with_progress_session_split(monkeypatch):
     assert set(trades['fold'].unique()) <= {'Asia', 'London', 'NY'}
 
 
+def test_run_wfv_with_progress_lowercase(monkeypatch):
+    import importlib
+    main = importlib.import_module('main')
+    df = sample_wfv_df_lower()
+    monkeypatch.setattr(main, 'maximize_ram', lambda: None)
+    trades = main.run_wfv_with_progress(df, ['Open', 'feat1', 'feat2'], 'label')
+    assert isinstance(trades, pd.DataFrame)
+
+
+def test_run_wfv_with_progress_close_fallback(monkeypatch):
+    import importlib
+    main = importlib.import_module('main')
+    df = sample_wfv_df_close_only()
+    monkeypatch.setattr(main, 'maximize_ram', lambda: None)
+    trades = main.run_wfv_with_progress(df, ['Open', 'feat1', 'feat2'], 'label')
+    assert isinstance(trades, pd.DataFrame)
+
+
 def test_split_by_session():
     from nicegold_v5.utils import split_by_session
     df = sample_df()


### PR DESCRIPTION
## Summary
- make `run_wfv_with_progress` accept lowercase `open` or fallback to `close`
- test WFV progress function with lowercase and close-only data
- document patch vWFV.7

## Testing
- `pytest -q`