### PR TITLE
Fix menu 7 to generate signals before WFV

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -542,4 +542,6 @@
 - แก้ run_wfv_with_progress รองรับคอลัมน์ 'open' หรือ 'close' เป็น 'Open' (Patch vWFV.7)
 ### 2025-11-23
 - ปรับเมนู 7 ใช้ `run_autofix_wfv` และ `simulate_partial_tp_safe` ร่วมกับ `SNIPER_CONFIG_Q3_TUNED` บนไฟล์ M1 (Patch v21.2.1)
+### 2025-11-24
+- แก้เมนู 7 ให้สร้างสัญญาณและตรวจสอบอินดิเคเตอร์ก่อนรัน `run_autofix_wfv` (Patch v21.2.2)
 

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -521,4 +521,6 @@
 - แก้ run_wfv_with_progress ให้ fallback คอลัมน์ 'Open' จาก 'open' หรือ 'close' (Patch vWFV.7)
 ## 2025-11-23
 - ปรับเมนู 7 เรียก `run_autofix_wfv` ทำ Walk-Forward แบบ AutoFix และบันทึก wfv_autofix_result.csv (Patch v21.2.1)
+## 2025-11-24
+- แก้เมนู 7 ให้สร้างสัญญาณก่อนรัน `run_autofix_wfv` และ fallback RELAX_CONFIG_Q3 หากไม่มีสัญญาณ (Patch v21.2.2)
 


### PR DESCRIPTION
## Summary
- fix menu 7 in `main.py` to generate signals and validate indicators before running AutoFix WFV
- update agents notes
- update changelog

## Testing
- `pytest -q`