### PR TITLE
ปรับ generate_ml_dataset_m1 ให้สร้าง trade log อัตโนมัติ

### DIFF
--- a/main.py
+++ b/main.py
@@ -396,7 +396,11 @@ def autopipeline():
             f"⚙️ Training LSTM hidden_dim={model_dim} batch_size={batch_size} lr={lr} optimizer={opt}"
         )
         # Step 2: Generate ML Dataset safely (after timestamp is confirmed)
-        generate_ml_dataset_m1(csv_path=M1_PATH, out_path="data/ml_dataset_m1.csv")
+        try:
+            generate_ml_dataset_m1(csv_path=M1_PATH, out_path="data/ml_dataset_m1.csv")
+        except Exception as e:
+            print("❌ ไม่สามารถสร้าง dataset ได้:", e)
+            return
 
         # Step 3: Train LSTM Classifier
         X, y = load_dataset("data/ml_dataset_m1.csv")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -603,3 +603,6 @@
 =======
 - ปรับ `build_trade_log` ให้คำนวณเวกเตอร์แทน iterrows ลดคอขวด และเพิ่ม unit test
 
+### 2025-12-18
+- ปรับ generate_ml_dataset_m1 สร้าง trade log อัตโนมัติเมื่อไม่พบไฟล์ และเพิ่ม error handling ใน autopipeline (Patch v22.4.3)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -583,3 +583,6 @@
 =======
 - ปรับ `build_trade_log` ให้เวกเตอร์ไลซ์ ลดเวลารัน และเพิ่มชุดทดสอบ
 
+## 2025-12-18
+- ปรับ generate_ml_dataset_m1 สร้าง trade log อัตโนมัติเมื่อไม่พบไฟล์ และเพิ่ม try/except ใน autopipeline (Patch v22.4.3)
+

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -54,7 +54,16 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv"):
     # Load trade log
     trade_log_path = "logs/trades_v12_tp1tp2.csv"
     if not os.path.exists(trade_log_path):
-        raise FileNotFoundError("❌ Trade log not found at logs/trades_v12_tp1tp2.csv")
+        print("⚠️ ไม่พบ trades_v12_tp1tp2.csv – กำลังสร้างโดยอัตโนมัติ...")
+        from nicegold_v5.entry import generate_signals
+        from nicegold_v5.exit import simulate_partial_tp_safe
+        df_trades = df.copy()
+        df_trades = generate_signals(df_trades)
+        df_trades["entry_time"] = df_trades["timestamp"]
+        trade_df = simulate_partial_tp_safe(df_trades)
+        os.makedirs("logs", exist_ok=True)
+        trade_df.to_csv(trade_log_path, index=False)
+        print("✅ สร้าง trade log ใหม่แล้วที่:", trade_log_path)
 
     trades = pd.read_csv(trade_log_path)
     trades["entry_time"] = pd.to_datetime(trades["entry_time"])

--- a/nicegold_v5/tests/test_autopipeline.py
+++ b/nicegold_v5/tests/test_autopipeline.py
@@ -22,7 +22,7 @@ def test_autopipeline(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
     monkeypatch.setattr(main, 'generate_signals', lambda df, config=None: df.assign(entry_signal=['long']*len(df)))
 
-    monkeypatch.setattr('nicegold_v5.ml_dataset_m1.generate_ml_dataset_m1', lambda: None)
+    monkeypatch.setattr('nicegold_v5.ml_dataset_m1.generate_ml_dataset_m1', lambda *a, **k: None)
     X_dummy = torch.zeros((1, 10, 7))
     y_dummy = torch.zeros((1, 1))
     monkeypatch.setattr('nicegold_v5.train_lstm_runner.load_dataset', lambda path: (X_dummy, y_dummy))

--- a/nicegold_v5/tests/test_lstm.py
+++ b/nicegold_v5/tests/test_lstm.py
@@ -39,6 +39,24 @@ def test_generate_ml_dataset_m1(tmp_path, monkeypatch):
     assert 'tp2_hit' in out_df.columns
 
 
+def test_generate_ml_dataset_auto_trade_log(tmp_path, monkeypatch):
+    df = sample_m1_data()
+    csv_path = tmp_path / 'XAUUSD_M1.csv'
+    df.to_csv(csv_path, index=False)
+    out_dir = tmp_path / 'data'
+    out_dir.mkdir()
+    out_csv = out_dir / 'ml_dataset_m1.csv'
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df: df)
+    monkeypatch.setattr(
+        'nicegold_v5.exit.simulate_partial_tp_safe',
+        lambda df: pd.DataFrame({'entry_time': df['entry_time'], 'exit_reason': ['tp2'] * len(df)})
+    )
+    generate_ml_dataset_m1(str(csv_path), str(out_csv))
+    assert out_csv.exists()
+    assert (tmp_path / 'logs' / 'trades_v12_tp1tp2.csv').exists()
+
+
 def test_train_lstm(tmp_path, monkeypatch):
     df = sample_m1_data()
     csv_path = tmp_path / 'XAUUSD_M1.csv'


### PR DESCRIPTION
## Notes
- เพิ่มการสร้าง trade log ใน `generate_ml_dataset_m1` และจับข้อผิดพลาดใน `autopipeline`
- ปรับ unit test ให้รองรับการเปลี่ยนแปลง และเพิ่มการทดสอบกรณีไม่มี trade log

## Summary
- `ml_dataset_m1.py` สร้าง trade log อัตโนมัติเมื่อไม่พบไฟล์เดิม
- `autopipeline` ครอบ `generate_ml_dataset_m1` ด้วย try/except
- ปรับปรุงชุดทดสอบและอัปเดตเอกสารการเปลี่ยนแปลง

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6839f1488a088325a36057443265493d