### PR TITLE
Fix autopipeline timestamp dtype

### DIFF
--- a/main.py
+++ b/main.py
@@ -352,6 +352,7 @@ def autopipeline(mode="default", train_epochs=1):
     df = load_csv_safe(M1_PATH)
     df = convert_thai_datetime(df)
     df["timestamp"] = parse_timestamp_safe(df["timestamp"], DATETIME_FORMAT)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
     df = df.dropna(subset=["timestamp"])
     df = df.sort_values("timestamp")
     df = sanitize_price_columns(df)
@@ -418,6 +419,9 @@ def autopipeline(mode="default", train_epochs=1):
         print("✅ บันทึกโมเดลที่ models/model_lstm_tp2.pth")
 
         df_feat = pd.read_csv("data/ml_dataset_m1.csv")
+        df_feat["timestamp"] = parse_timestamp_safe(df_feat["timestamp"], DATETIME_FORMAT)
+        df_feat["timestamp"] = pd.to_datetime(df_feat["timestamp"], errors="coerce")
+        df_feat = df_feat.dropna(subset=["timestamp"])
         feat_cols = [
             "gain_z",
             "ema_slope",

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -612,3 +612,9 @@
 ### 2025-12-20
 - เพิ่มโหมด `mode="full"` ใน `autopipeline` และอัปเดตเมนูใน `welcome()` เป็น Ultimate Mode (Patch v22.6.4)
 
+### 2025-12-21
+- แก้ `autopipeline` ให้แปลง `timestamp` ในชุดข้อมูล ML ก่อน merge ป้องกัน ValueError dtype mismatch (Patch v22.6.5)
+
+### 2025-12-22
+- เพิ่ม `pd.to_datetime` ใน autopipeline สำหรับทั้ง df และ df_feat ก่อน merge (Patch v22.6.6)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -592,3 +592,9 @@
 ## 2025-12-20
 - เพิ่ม `mode="full"` ให้ฟังก์ชัน `autopipeline` และปรับเมนูใน `welcome()` เป็น Ultimate Mode (Patch v22.6.4)
 
+## 2025-12-21
+- แก้ `autopipeline` ให้แปลง `timestamp` ใน ML dataset เป็น datetime64 ก่อน merge ป้องกัน ValueError (Patch v22.6.5)
+
+## 2025-12-22
+- เพิ่ม `pd.to_datetime` ใน autopipeline สำหรับทั้ง df และ df_feat ก่อน merge (Patch v22.6.6)
+


### PR DESCRIPTION
## Notes
- Ensure `timestamp` columns are explicitly converted with `pd.to_datetime` before merging.
- Documented patch v22.6.6 in `AGENTS.md` and `changelog.md`.
- All unit tests pass (torch tests skipped).


------
https://chatgpt.com/codex/tasks/task_e_6839f9dbdd008325a5062e9784528520