### PR TITLE
Apply pd.to_datetime before merge

### DIFF
--- a/main.py
+++ b/main.py
@@ -352,6 +352,7 @@ def autopipeline(mode="default", train_epochs=1):
     df = load_csv_safe(M1_PATH)
     df = convert_thai_datetime(df)
     df["timestamp"] = parse_timestamp_safe(df["timestamp"], DATETIME_FORMAT)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
     df = df.dropna(subset=["timestamp"])
     df = df.sort_values("timestamp")
     df = sanitize_price_columns(df)
@@ -419,6 +420,7 @@ def autopipeline(mode="default", train_epochs=1):
 
         df_feat = pd.read_csv("data/ml_dataset_m1.csv")
         df_feat["timestamp"] = parse_timestamp_safe(df_feat["timestamp"], DATETIME_FORMAT)
+        df_feat["timestamp"] = pd.to_datetime(df_feat["timestamp"], errors="coerce")
         df_feat = df_feat.dropna(subset=["timestamp"])
         feat_cols = [
             "gain_z",

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -615,3 +615,6 @@
 ### 2025-12-21
 - แก้ `autopipeline` ให้แปลง `timestamp` ในชุดข้อมูล ML ก่อน merge ป้องกัน ValueError dtype mismatch (Patch v22.6.5)
 
+### 2025-12-22
+- เพิ่ม `pd.to_datetime` ใน autopipeline สำหรับทั้ง df และ df_feat ก่อน merge (Patch v22.6.6)
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -595,3 +595,6 @@
 ## 2025-12-21
 - แก้ `autopipeline` ให้แปลง `timestamp` ใน ML dataset เป็น datetime64 ก่อน merge ป้องกัน ValueError (Patch v22.6.5)
 
+## 2025-12-22
+- เพิ่ม `pd.to_datetime` ใน autopipeline สำหรับทั้ง df และ df_feat ก่อน merge (Patch v22.6.6)
+


### PR DESCRIPTION
## Summary
- ensure autopipeline converts timestamps to datetime
- record patch notes for autopipeline timestamp fix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6839fe379d9c8325852c3b86386d86e3