### PR TITLE
อัปเกรด get_resource_plan และปรับชุดทดสอบ

### DIFF
--- a/main.py
+++ b/main.py
@@ -363,18 +363,25 @@ def autopipeline(mode="default", train_epochs=1):
     plan = get_resource_plan()
     device = plan["device"]
     DEVICE = torch.device(device) if torch else None
-    print(f"🖥️ Device: {plan['gpu']}")
-    print(
-        f"💾 RAM: {plan['ram']:.1f} GB | CPU Threads: {plan['threads']}"
-    )
+    print("\n🧠 AI Resource Plan Summary:")
+    print(f"   ▸ GPU       : {plan['gpu']}")
+    print(f"   ▸ RAM       : {plan['ram']:.2f} GB")
+    print(f"   ▸ VRAM      : {plan['vram']:.2f} GB")
+    print(f"   ▸ CUDA Core : {plan['cuda_cores']}")
+    print(f"   ▸ Threads   : {plan['threads']}")
+    print(f"   ▸ Precision : {plan['precision']}")
+    print(f"   ▸ Batch     : {plan['batch_size']}")
+    print(f"   ▸ ModelDim  : {plan['model_dim']}")
+    print(f"   ▸ Epochs    : {plan['train_epochs']}")
+    print(f"   ▸ Optimizer : {plan['optimizer']}")
+    print("✅ บันทึก resource_plan.json แล้วที่ logs/")
+
     batch_size = plan["batch_size"]
     model_dim = plan["model_dim"]
     n_folds = plan["n_folds"]
-    lr = plan["lr"]
+    lr = plan.get("lr", 0.001)
     opt = plan["optimizer"]
-    print(
-        f"⚙️ Auto Config → batch_size={batch_size}, model_dim={model_dim}, n_folds={n_folds}, optimizer={opt}, lr={lr}"
-    )
+    train_epochs = plan.get("train_epochs", train_epochs)
 
     # Load and prepare CSV for all pipeline modes
     df = load_csv_safe(M1_PATH)

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -640,3 +640,7 @@
 ### 2025-12-27
 - เพิ่มโหมด `fusion_ai` ใน `autopipeline` ผสาน LSTM, SHAP, MetaClassifier และ RL Fallback (Patch v24.0.0)
 - ปรับ `ai_master` ให้ฝึก MetaClassifier และ RL Agent พร้อมวิเคราะห์ SHAP (Patch v24.1.0)
+
+### 2025-12-28
+- ปรับ `get_resource_plan` ตรวจสอบ VRAM และ CUDA cores พร้อมบันทึก `logs/resource_plan.json`
+- แสดง AI Resource Plan Summary ใน `autopipeline`

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -620,3 +620,7 @@
 - เพิ่มโหมด `fusion_ai` ใน `autopipeline` รวม LSTM + SHAP + MetaClassifier + RL fallback
 - ปรับ `autopipeline` โหมด `ai_master` ฝึก MetaClassifier และ RL Agent และบันทึกฟีเจอร์ SHAP
 - เพิ่มโมดูล `meta_classifier.py` และชุดทดสอบใหม่
+
+## 2025-12-28
+- ปรับปรุง `get_resource_plan` ตรวจสอบ VRAM และ CUDA cores เพิ่มฟิลด์ precision และ train_epochs
+- บันทึกข้อมูลแผนทรัพยากรลง `logs/resource_plan.json` และแสดงผลใน `autopipeline`

--- a/nicegold_v5/tests/test_autopipeline.py
+++ b/nicegold_v5/tests/test_autopipeline.py
@@ -124,6 +124,8 @@ def test_autopipeline(monkeypatch, tmp_path, capsys):
     plan = {
         'device': 'cpu',
         'gpu': 'CPU',
+        'vram': 0.0,
+        'cuda_cores': 0,
         'ram': 8.0,
         'threads': 2,
         'batch_size': 64,
@@ -131,6 +133,8 @@ def test_autopipeline(monkeypatch, tmp_path, capsys):
         'n_folds': 5,
         'optimizer': 'sgd',
         'lr': 0.01,
+        'precision': 'float32',
+        'train_epochs': 30,
     }
     monkeypatch.setattr(main, 'get_resource_plan', lambda: plan)
 
@@ -192,6 +196,8 @@ def test_ai_master_pipeline(monkeypatch, tmp_path, capsys):
     plan = {
         'device': 'cpu',
         'gpu': 'CPU',
+        'vram': 0.0,
+        'cuda_cores': 0,
         'ram': 8.0,
         'threads': 2,
         'batch_size': 64,
@@ -199,6 +205,8 @@ def test_ai_master_pipeline(monkeypatch, tmp_path, capsys):
         'n_folds': 5,
         'optimizer': 'sgd',
         'lr': 0.01,
+        'precision': 'float32',
+        'train_epochs': 30,
     }
     monkeypatch.setattr(main, 'get_resource_plan', lambda: plan)
     monkeypatch.setattr('nicegold_v5.optuna_tuner.start_optimization', lambda df_feat, n_trials=100: types.SimpleNamespace(best_trial=types.SimpleNamespace(params={})))
@@ -261,6 +269,8 @@ def test_fusion_ai_pipeline(monkeypatch, tmp_path, capsys):
     plan = {
         'device': 'cpu',
         'gpu': 'CPU',
+        'vram': 0.0,
+        'cuda_cores': 0,
         'ram': 8.0,
         'threads': 2,
         'batch_size': 64,
@@ -268,6 +278,8 @@ def test_fusion_ai_pipeline(monkeypatch, tmp_path, capsys):
         'n_folds': 5,
         'optimizer': 'sgd',
         'lr': 0.01,
+        'precision': 'float32',
+        'train_epochs': 30,
     }
     monkeypatch.setattr(main, 'get_resource_plan', lambda: plan)
     def dummy_autopipeline(*a, **k):

--- a/nicegold_v5/tests/test_autopipeline_no_torch.py
+++ b/nicegold_v5/tests/test_autopipeline_no_torch.py
@@ -25,6 +25,8 @@ def test_autopipeline_no_torch(monkeypatch, tmp_path, capsys):
     plan = {
         'device': 'cpu',
         'gpu': 'CPU',
+        'vram': 0.0,
+        'cuda_cores': 0,
         'ram': 8.0,
         'threads': 2,
         'batch_size': 64,
@@ -32,6 +34,8 @@ def test_autopipeline_no_torch(monkeypatch, tmp_path, capsys):
         'n_folds': 5,
         'optimizer': 'sgd',
         'lr': 0.01,
+        'precision': 'float32',
+        'train_epochs': 30,
     }
     monkeypatch.setattr(main, 'get_resource_plan', lambda: plan)
 

--- a/nicegold_v5/tests/test_resource_plan.py
+++ b/nicegold_v5/tests/test_resource_plan.py
@@ -4,21 +4,27 @@ import sys
 
 
 def test_get_resource_plan(monkeypatch):
-    dummy_psutil = types.SimpleNamespace(virtual_memory=lambda: types.SimpleNamespace(total=16 * 1024**3))
+    dummy_psutil = types.SimpleNamespace(
+        virtual_memory=lambda: types.SimpleNamespace(total=16 * 1024**3),
+        cpu_count=lambda logical=False: 4,
+    )
     dummy_cuda = types.SimpleNamespace(
         is_available=lambda: True,
         get_device_name=lambda idx: "DummyGPU",
+        get_device_properties=lambda idx: types.SimpleNamespace(total_memory=16 * 1024**3, multi_processor_count=5),
     )
-    dummy_torch = types.SimpleNamespace(cuda=dummy_cuda)
+    dummy_torch = types.SimpleNamespace(
+        cuda=dummy_cuda,
+        set_float32_matmul_precision=lambda x: None,
+    )
     monkeypatch.setitem(sys.modules, 'psutil', dummy_psutil)
     monkeypatch.setitem(sys.modules, 'torch', dummy_torch)
-    import multiprocessing
-    monkeypatch.setattr(multiprocessing, 'cpu_count', lambda: 4)
 
     utils = importlib.reload(importlib.import_module('nicegold_v5.utils'))
     plan = utils.get_resource_plan()
     assert plan['device'] == 'cuda'
     assert plan['gpu'] == 'DummyGPU'
-    assert plan['batch_size'] == 128
-    assert plan['optimizer'] == 'adam'
-    assert plan['n_folds'] == 6
+    assert plan['batch_size'] == 384
+    assert plan['optimizer'] == 'adamw'
+    assert plan['n_folds'] == 7
+    assert plan['precision'] == 'float16'


### PR DESCRIPTION
## Notes
- ปรับ `get_resource_plan` ใน `utils.py` ให้ตรวจสอบ VRAM, CUDA cores และบันทึก `logs/resource_plan.json`
- แก้ `autopipeline` ให้แสดง AI Resource Plan Summary และใช้ค่า train_epochs อัตโนมัติ
- อัพเดต AGENTS.md และ changelog.md
- ปรับชุดทดสอบให้รองรับแผนทรัพยากรแบบใหม่

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a160ee4e4832594088eceb06cd2dc