### PR TITLE
Patch v24.2.4: เพิ่มระบบจับเวลา LSTM Training

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -650,3 +650,7 @@
   ป้องกัน KeyError 'close' ระหว่าง Optuna (Patch v24.1.1)
 ### 2025-12-30
 - เพิ่ม Mixed Precision Training ใน `train_lstm_runner` พร้อม CPU fallback และอัพเดตชุดทดสอบ (Patch v24.2.3)
+
+### 2025-12-31
+- เพิ่มระบบจับเวลา load, forward, backward และ optimizer step ใน `train_lstm_runner`
+- แสดง bottleneck ต่อ epoch และใช้ `prefetch_factor` เพิ่มความเร็ว I/O (Patch v24.2.4)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -631,3 +631,6 @@
 ## 2025-12-30
 - เพิ่มการเทรนแบบ Mixed Precision (AMP) ใน `train_lstm_runner`
 - ใช้งาน CPU fallback เมื่อไม่พบ GPU และปรับชุดทดสอบ (Patch v24.2.3)
+## 2025-12-31
+- เพิ่มระบบจับเวลา load, forward, backward และ optimizer step ใน `train_lstm_runner`
+- แสดง bottleneck ต่อ epoch และใช้ `prefetch_factor` เพิ่มความเร็ว I/O (Patch v24.2.4)


### PR DESCRIPTION
## Notes
- สนทนาภาษาไทย

## Summary
- ปรับ `train_lstm_runner` ให้เก็บเวลาการทำงานของ data load, forward, backward และ optimizer step พร้อมแสดง bottleneck ต่อ epoch
- เพิ่ม `prefetch_factor` และ `num_workers` ใน `DataLoader` เพื่อเร่ง I/O
- อัปเดต `AGENTS.md` และ `changelog.md` สำหรับ Patch v24.2.4

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a976fee50832581c7a43037a58b87