### PR TITLE
Patch v24.1.1 dataset & tuner fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -401,6 +401,7 @@ def autopipeline(mode="default", train_epochs=1):
         print("\n🧠 [AI Master Pipeline] เริ่มทำงานแบบครบวงจร (SHAP + Optuna + Guard + WFV)")
         generate_ml_dataset_m1(csv_path=M1_PATH, out_path="data/ml_dataset_m1.csv")
         X, y = load_dataset("data/ml_dataset_m1.csv")
+        print(f"[Debug] y unique: {y.unique()}, value_counts: {np.unique(y, return_counts=True)}")
         model = train_lstm(
             X,
             y,
@@ -539,6 +540,7 @@ def autopipeline(mode="default", train_epochs=1):
 
         generate_ml_dataset_m1(csv_path=M1_PATH, out_path="data/ml_dataset_m1.csv")
         X, y = load_dataset("data/ml_dataset_m1.csv")
+        print(f"[Debug] y unique: {y.unique()}, value_counts: {np.unique(y, return_counts=True)}")
         model = train_lstm(X, y, epochs=train_epochs)
         os.makedirs("models", exist_ok=True)
         torch.save(model.state_dict(), "models/model_lstm_tp2.pth")
@@ -606,6 +608,7 @@ def autopipeline(mode="default", train_epochs=1):
 
         # Step 3: Train LSTM Classifier
         X, y = load_dataset("data/ml_dataset_m1.csv")
+        print(f"[Debug] y unique: {y.unique()}, value_counts: {np.unique(y, return_counts=True)}")
         model = train_lstm(
             X,
             y,
@@ -890,6 +893,7 @@ def welcome():
         print("🚀 สร้าง Dataset และฝึก LSTM Classifier สำหรับ TP2 Prediction...")
         generate_ml_dataset_m1()
         X, y = load_dataset("data/ml_dataset_m1.csv")
+        print(f"[Debug] y unique: {y.unique()}, value_counts: {np.unique(y, return_counts=True)}")
         model = train_lstm(X, y)
         os.makedirs("models", exist_ok=True)
         torch.save(model.state_dict(), "models/model_lstm_tp2.pth")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -654,3 +654,9 @@
 ### 2025-12-31
 - เพิ่มระบบจับเวลา load, forward, backward และ optimizer step ใน `train_lstm_runner`
 - แสดง bottleneck ต่อ epoch และใช้ `prefetch_factor` เพิ่มความเร็ว I/O (Patch v24.2.4)
+
+### 2026-01-01
+- แก้ `optuna_tuner.objective` ตรวจสอบคอลัมน์ `timestamp` และแปลงเป็น datetime
+- ปรับ `generate_ml_dataset_m1` ให้สร้างคอลัมน์ `entry_score`, `gain_z` หากหายไป
+- เพิ่ม debug แสดงค่า label ใน `autopipeline`
+- อัปเดต `MetaClassifier.predict` ตรวจสอบฟีเจอร์ขาดก่อนทำนาย

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -634,3 +634,9 @@
 ## 2025-12-31
 - เพิ่มระบบจับเวลา load, forward, backward และ optimizer step ใน `train_lstm_runner`
 - แสดง bottleneck ต่อ epoch และใช้ `prefetch_factor` เพิ่มความเร็ว I/O (Patch v24.2.4)
+
+## 2026-01-01
+- แก้ objective ใน `optuna_tuner` ตรวจสอบและแปลง `timestamp`
+- ปรับ `generate_ml_dataset_m1` เติมคอลัมน์ `entry_score`, `gain_z` หากไม่พบใน trade log
+- พิมพ์ debug ค่า label ใน `autopipeline`
+- อัปเดต `MetaClassifier.predict` ใส่ค่า 0.0 หากฟีเจอร์ขาด

--- a/nicegold_v5/meta_classifier.py
+++ b/nicegold_v5/meta_classifier.py
@@ -11,5 +11,8 @@ class MetaClassifier:
         self.model = joblib.load(model_path)
 
     def predict(self, df: pd.DataFrame):
+        for feat in FEATURES:
+            if feat not in df.columns:
+                df[feat] = 0.0
         X = df[FEATURES]
         return self.model.predict(X)

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -67,6 +67,11 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv"):
 
     trades = pd.read_csv(trade_log_path)
     trades["entry_time"] = pd.to_datetime(trades["entry_time"])
+    # [Patch v24.1.1] 🛠️ Ensure 'entry_score', 'gain_z' columns exist in trades
+    if "entry_score" not in trades.columns:
+        trades["entry_score"] = 1.0
+    if "gain_z" not in trades.columns:
+        trades["gain_z"] = 0.0
 
     df["tp2_hit"] = 0
     tp2_entries = trades[trades["exit_reason"] == "tp2"]["entry_time"]

--- a/nicegold_v5/optuna_tuner.py
+++ b/nicegold_v5/optuna_tuner.py
@@ -18,6 +18,11 @@ def objective(trial) -> float:
     }
 
     df = session_folds.get("London", pd.DataFrame()).copy()
+    # [Patch v24.1.1] 🔧 Ensure 'timestamp' column exists and is datetime
+    if "timestamp" not in df.columns and df.index.name == "timestamp":
+        df = df.reset_index()
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
     if df.empty:
         return -999
     df = generate_signals(df, config=config)


### PR DESCRIPTION
## Summary
- ensure timestamp column exists and is datetime in `optuna_tuner`
- guarantee `entry_score` and `gain_z` columns exist when generating ML dataset
- add debug print of label distribution when loading dataset in `autopipeline`
- robust feature check in `MetaClassifier`
- update patch notes in `AGENTS.md` and `changelog.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aa98768a8832597b9b81830e00ff5