### PR TITLE
ปรับ main เรียก welcome แทน autopipeline

### DIFF
--- a/main.py
+++ b/main.py
@@ -822,7 +822,7 @@ if __name__ == "__main__":
         run_clean_backtest(df)
         print("✅ Done: Clean Backtest Completed")
     else:
-        autopipeline()
+        welcome()
     # [Patch v12.4.1] Example of how choice 7 might be handled if menu was active
     # elif choice == 7:  # This would be part of the active menu loop in welcome()
     #     print("\n🚀 เริ่มรัน CleanBacktest ด้วย AutoFix + Export...")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -666,3 +666,5 @@
 - อัปเดต changelog และเพิ่ม unit test หากจำเป็น
 ### 2026-01-03
 - เพิ่มชุดทดสอบ fix_engine ครอบคลุม run_self_diagnostic, auto_fix_logic และ simulate_and_autofix
+### 2026-01-04
+- ปรับ main.py เรียก welcome() ใน __main__ แทน autopipeline

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -645,3 +645,5 @@
 - เพิ่มฟังก์ชัน `run_smart_fast_qa` เรียก pytest เร็ว ๆ
 ## 2026-01-03
 - เพิ่มชุดทดสอบโมดูล fix_engine (run_self_diagnostic, auto_fix_logic, simulate_and_autofix)
+## 2026-01-04
+- ปรับ __main__ ให้เรียก welcome() เมื่อไม่ได้ใช้โหมด clean


### PR DESCRIPTION
## Notes
- อัปเดต `main.py` ให้เรียก `welcome()` เมื่อไม่ได้ใช้โหมด `clean`
- ปรับ `AGENTS.md` และ `changelog.md` ตามแนวทางเอกสาร
- ทดสอบ `pytest` ผ่านทั้งหมด


------
https://chatgpt.com/codex/tasks/task_e_683abd3c0a148325acb2d5b34c8ae3d9