### PR TITLE
Apply patch v24.3.2 updates

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -675,3 +675,8 @@
 - ปรับ `generate_ml_dataset_m1` สร้าง trade log ใหม่ทุกครั้งด้วย `SNIPER_CONFIG_ULTRA_OVERRIDE` (Patch v24.3.0)
 ### 2026-01-07
 - เพิ่มชุดทดสอบ wfv และ train_lstm_runner ให้ coverage ทะลุ 90%
+### 2026-01-08
+- ปรับ generate_signals_v8_0 ให้ override volume=1 เมื่อ gain_z_thresh <= -9 และ volume ว่าง (Patch v24.3.2)
+- เพิ่ม log volume stat และนับ tp2_hit ใน generate_ml_dataset_m1 (Patch v24.3.2)
+- อัปเดต LSTMClassifier ใช้ BCEWithLogitsLoss และลบ sigmoid ใน deep_model_m1 (Patch v24.3.2)
+- ปรับ train_lstm_runner ใช้ BCEWithLogitsLoss และอัปเดต unit test

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -654,3 +654,8 @@
 - ปรับ `generate_ml_dataset_m1` ให้สร้าง trade log ใหม่ทุกครั้งด้วย `SNIPER_CONFIG_ULTRA_OVERRIDE` (Patch v24.3.0)
 ## 2026-01-07
 - เพิ่มเทส wfv และ train_lstm_runner ครอบคลุมฟังก์ชันย่อย ทำ coverage เกิน 90%
+## 2026-01-08
+- [Patch v24.3.2] ปรับ generate_signals_v8_0 ให้ override volume=1 หากชุดข้อมูล volume ว่างและใช้ ultra override
+- [Patch v24.3.2] เพิ่ม log ตรวจสอบ volume และแสดงจำนวน tp2_hit ใน generate_ml_dataset_m1
+- [Patch v24.3.2] ปรับ LSTMClassifier ใช้ BCEWithLogitsLoss และตัด sigmoid layer
+- [Patch v24.3.2] เปลี่ยน train_lstm_runner เป็น BCEWithLogitsLoss และอัปเดต unit test

--- a/nicegold_v5/deep_model_m1.py
+++ b/nicegold_v5/deep_model_m1.py
@@ -7,10 +7,10 @@ class LSTMClassifier(nn.Module):
         super(LSTMClassifier, self).__init__()
         self.lstm = nn.LSTM(input_dim, hidden_dim, num_layers, batch_first=True)
         self.fc = nn.Linear(hidden_dim, output_dim)
-        self.sigmoid = nn.Sigmoid()
+        # [Patch v24.3.2] ⚡️ Remove sigmoid layer (use BCEWithLogitsLoss instead)
 
     def forward(self, x):
         out, _ = self.lstm(x)
         out = out[:, -1, :]
         out = self.fc(out)
-        return self.sigmoid(out)
+        return out  # no sigmoid, for BCEWithLogitsLoss

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -202,6 +202,11 @@ def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.Da
     df["lot_suggested"] = 0.05
 
     # --- Indicators ---
+    # [Patch v24.3.2] 🛡️ Auto-fix volume==0 dev set (ultra override only)
+    if config and config.get("gain_z_thresh", 0) <= -9.0:
+        if (df["volume"].max() == 0) or (df["volume"].isnull().all()):
+            print("[Patch v24.3.2] 🛡️ Ultra Override: force volume = 1.0 for signal fallback.")
+            df["volume"] = 1.0
     df["ema_15"] = df["close"].ewm(span=15).mean()
     df["ema_50"] = df["close"].ewm(span=50).mean()
     df["atr"] = (df["high"] - df["low"]).rolling(14).mean()

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -55,6 +55,7 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv"):
     trade_log_path = "logs/trades_v12_tp1tp2.csv"
     # [Patch v24.3.0] 🛡️ Always regenerate trade log with ultra config for ML (ensure TP2 sample)
     print("[Patch v24.3.0] 🛡️ Generating trade log for ML with SNIPER_CONFIG_ULTRA_OVERRIDE...")
+    print("[Patch v24.3.2] 🔎 Volume stat (dev):", df["volume"].describe())
     from nicegold_v5.config import SNIPER_CONFIG_ULTRA_OVERRIDE
     from nicegold_v5.entry import generate_signals
     from nicegold_v5.exit import simulate_partial_tp_safe
@@ -77,6 +78,7 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv"):
     df["tp2_hit"] = 0
     tp2_entries = trades[trades["exit_reason"] == "tp2"]["entry_time"]
     df.loc[df["timestamp"].isin(tp2_entries), "tp2_hit"] = 1
+    print(f"[Patch v24.3.2] ✅ ML dataset: tp2_hit count = {df['tp2_hit'].sum()}/{len(df)}")
     df = df.dropna().reset_index(drop=True)
     out_dir = os.path.dirname(out_path)
     if out_dir:

--- a/nicegold_v5/tests/test_train_lstm_runner_unit.py
+++ b/nicegold_v5/tests/test_train_lstm_runner_unit.py
@@ -69,7 +69,7 @@ def test_train_lstm_stub(monkeypatch):
             pass
 
     monkeypatch.setattr(tlr, 'LSTMClassifier', DummyModel)
-    monkeypatch.setattr(tlr, 'nn', types.SimpleNamespace(BCELoss=lambda: lambda preds, target: SimpleNamespace(item=lambda: 0.0)))
+    monkeypatch.setattr(tlr, 'nn', types.SimpleNamespace(BCEWithLogitsLoss=lambda: lambda preds, target: SimpleNamespace(item=lambda: 0.0)))
     monkeypatch.setattr(tlr, 'GradScaler', lambda enabled=True: DummyScaler())
     class DummyCast:
         def __init__(self, enabled=True):

--- a/nicegold_v5/train_lstm_runner.py
+++ b/nicegold_v5/train_lstm_runner.py
@@ -51,7 +51,8 @@ def train_lstm(
         num_workers=2,
         prefetch_factor=2,
     )
-    criterion = nn.BCELoss()
+    # [Patch v24.3.2] ⚡️ Use BCEWithLogitsLoss for amp+sigmoid safety
+    criterion = nn.BCEWithLogitsLoss()
     optimizer = (
         optim.SGD(model.parameters(), lr=lr)
         if optimizer_name == "sgd"


### PR DESCRIPTION
## Summary
- override volume when dataset has zero volume with ultra override
- log volume stats and verify tp2 count when building ML dataset
- drop sigmoid from LSTMClassifier and switch to BCEWithLogitsLoss
- use BCEWithLogitsLoss in training runner
- update unit tests, docs and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683acb12a84c8325bf9bfc3bcd654423