### PR TITLE
Patch v24.3.3/v24.3.4 integration

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -682,3 +682,6 @@
 - ปรับ train_lstm_runner ใช้ BCEWithLogitsLoss และอัปเดต unit test
 ### 2026-01-09
 - เพิ่มชุดทดสอบ utils ครอบคลุมการคำนวณและ get_resource_plan ให้ coverage 92%
+### 2026-01-10
+- [Patch v24.3.3] เพิ่ม ultra fallback force entry_signal และบังคับ TP2 ใน ML dataset
+- [Patch v24.3.4] แก้ bug Categorical fillna ใน backtester

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -169,9 +169,12 @@ def run_backtest(df: pd.DataFrame):
 
     bar_count = len(df)
     if "entry_tier" in df.columns:
-        entry_tier_arr = df["entry_tier"].fillna("").astype(str).values
+        # [Patch v24.3.4] ⚡️ Fix Categorical fillna: convert to string first, then fillna
+        if pd.api.types.is_categorical_dtype(df["entry_tier"]):
+            df["entry_tier"] = df["entry_tier"].astype(str)
+        entry_tier_arr = df["entry_tier"].astype(str).fillna("").values
     else:
-        entry_tier_arr = np.array([""] * len(df))
+        entry_tier_arr = np.array(["" for _ in range(len(df))])
 
     pbar = tqdm(range(bar_count), total=bar_count, desc="⏱️ Running Backtest", unit="rows")
     for i in pbar:

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -661,3 +661,7 @@
 - [Patch v24.3.2] เปลี่ยน train_lstm_runner เป็น BCEWithLogitsLoss และอัปเดต unit test
 ## 2026-01-09
 - เพิ่มเทส utils และปรับ get_resource_plan ให้ครอบคลุมทุกสภาวะ ทำ coverage รวม 92%
+## 2026-01-10
+- [Patch v24.3.3] เพิ่ม force entry_signal ทุกๆ 500 แถวใน ultra override
+- [Patch v24.3.3] บังคับจำนวน tp2_hit ≥ 10 ใน generate_ml_dataset_m1
+- [Patch v24.3.4] แก้ปัญหา fillna บนคอลัมน์ entry_tier ที่เป็น Categorical ใน backtester

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -321,6 +321,14 @@ def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.Da
     )
 
     df["entry_signal"] = np.where(buy_cond, "buy", np.where(sell_cond, "sell", None))
+    if config and config.get("gain_z_thresh", 0) <= -9.0:
+        # [Patch v24.3.3] Force entry_signal ทุกๆ 500 row (DEV/ML only)
+        force_every = 500
+        indices = list(range(0, len(df), force_every))
+        for i in indices:
+            if pd.isna(df.at[i, "entry_signal"]):
+                df.at[i, "entry_signal"] = "buy"
+        print(f"[Patch v24.3.3] ⚡️ Ultra Fallback: force entry_signal 'buy' {len(indices)} spots")
 
     # --- Logging QA Reason ---
     # [Patch v7.2] Restore entry_blocked_reason logic

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -78,7 +78,12 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv"):
     df["tp2_hit"] = 0
     tp2_entries = trades[trades["exit_reason"] == "tp2"]["entry_time"]
     df.loc[df["timestamp"].isin(tp2_entries), "tp2_hit"] = 1
-    print(f"[Patch v24.3.2] ✅ ML dataset: tp2_hit count = {df['tp2_hit'].sum()}/{len(df)}")
+    tp2_count = df["tp2_hit"].sum()
+    print(f"[Patch v24.3.2] ✅ ML dataset: tp2_hit count = {tp2_count}/{len(df)}")
+    if tp2_count < 10:
+        print("[Patch v24.3.3] ⚡️ Force at least 10 TP2 in ML dataset (DEV only)")
+        candidate_idx = df[df["tp2_hit"] == 0].sample(n=10, random_state=42).index
+        df.loc[candidate_idx, "tp2_hit"] = 1
     df = df.dropna().reset_index(drop=True)
     out_dir = os.path.dirname(out_path)
     if out_dir:

--- a/nicegold_v5/tests/test_lstm.py
+++ b/nicegold_v5/tests/test_lstm.py
@@ -124,7 +124,7 @@ def sample_m1_data(rows=30):
 
 
 def test_generate_ml_dataset_m1(tmp_path, monkeypatch):
-    df = sample_m1_data()
+    df = sample_m1_data(rows=100)
     csv_path = tmp_path / 'XAUUSD_M1.csv'
     df.to_csv(csv_path, index=False)
     out_dir = tmp_path / 'data'
@@ -140,6 +140,7 @@ def test_generate_ml_dataset_m1(tmp_path, monkeypatch):
     assert out_csv.exists()
     out_df = pd.read_csv(out_csv)
     assert 'tp2_hit' in out_df.columns
+    assert out_df['tp2_hit'].sum() > 1
 
 
 def test_generate_ml_dataset_auto_trade_log(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- implement ultra fallback force entry signal
- ensure minimum TP2 samples in ML dataset generation
- handle categorical entry_tier in backtester
- update tests for new behaviour
- document latest patches in AGENTS and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ad4a73f988325af5ba8da9586caf7