### PR TITLE
แก้ไข DeprecationWarning ใน backtester

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -685,3 +685,5 @@
 ### 2026-01-10
 - [Patch v24.3.3] เพิ่ม ultra fallback force entry_signal และบังคับ TP2 ใน ML dataset
 - [Patch v24.3.4] แก้ bug Categorical fillna ใน backtester
+### 2026-01-11
+- [Patch v24.3.5] ปรับ backtester ใช้ isinstance(df["entry_tier"].dtype, pd.CategoricalDtype) แทน is_categorical_dtype

--- a/nicegold_v5/backtester.py
+++ b/nicegold_v5/backtester.py
@@ -170,7 +170,8 @@ def run_backtest(df: pd.DataFrame):
     bar_count = len(df)
     if "entry_tier" in df.columns:
         # [Patch v24.3.4] ⚡️ Fix Categorical fillna: convert to string first, then fillna
-        if pd.api.types.is_categorical_dtype(df["entry_tier"]):
+        dtype = df["entry_tier"].dtype
+        if isinstance(dtype, pd.CategoricalDtype):
             df["entry_tier"] = df["entry_tier"].astype(str)
         entry_tier_arr = df["entry_tier"].astype(str).fillna("").values
     else:

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -665,3 +665,5 @@
 - [Patch v24.3.3] เพิ่ม force entry_signal ทุกๆ 500 แถวใน ultra override
 - [Patch v24.3.3] บังคับจำนวน tp2_hit ≥ 10 ใน generate_ml_dataset_m1
 - [Patch v24.3.4] แก้ปัญหา fillna บนคอลัมน์ entry_tier ที่เป็น Categorical ใน backtester
+## 2026-01-11
+- [Patch v24.3.5] ปรับ backtester ตรวจสอบ dtype Categorical แบบใหม่ ไม่ใช้ is_categorical_dtype


### PR DESCRIPTION
## Summary
- ตรวจสอบ dtype ของ `entry_tier` ด้วย `isinstance` แทน `is_categorical_dtype`
- อัปเดต changelog และ AGENTS ให้ระบุ Patch v24.3.5

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ad880160c8325991e67cd7264c192