### PR TITLE
ปรับปรุง QA Override ในฟังก์ชันสัญญาณ

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -727,4 +727,6 @@
 - [Patch v26.0.1] บังคับเปิดฝั่ง BUY/SELL ทุกคอนฟิกและทุกเซสชัน ป้องกันสัญญาณถูกบล็อกโดยไม่ตั้งใจ
 ### 2026-01-25
 - [Patch v26.0.1] ปรับ generate_signals และ generate_signals_v12_0 เพิ่ม QA Override ให้ปิด disable_buy/disable_sell เสมอ
+### 2026-01-26
+- ปรับปรุง QA Override ใน generate_signals และ generate_signals_v12_0 ให้ตรวจค่าจาก config ก่อนตั้งค่าใหม่ พร้อมข้อความ log ชัดเจน
 

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -707,4 +707,6 @@
 - [Patch v26.0.1] บังคับเปิดฝั่ง BUY/SELL ทุกคอนฟิกและทุกเซสชัน ป้องกันสัญญาณถูกบล็อก
 ## 2026-01-25
 - [Patch v26.0.1] ปรับฟังก์ชัน generate_signals และ generate_signals_v12_0 ให้ QA Override disable_buy/disable_sell
+## 2026-01-26
+- ปรับข้อความ QA Override และตรวจ config ก่อนตั้งค่าใหม่ใน generate_signals และ generate_signals_v12_0
 

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -755,14 +755,13 @@ def generate_signals(df: pd.DataFrame, config: dict | None = None) -> pd.DataFra
     ปลดล็อกฝั่ง Buy/Sell ทุกจุด (QA Guard)
     """
     config = config or {}
+    # Force unlock both sides regardless of any caller config
+    if config.get("disable_buy", None) is not False:
+        print("[Patch v26.0.1] QA Override: force disable_buy = False")
+    if config.get("disable_sell", None) is not False:
+        print("[Patch v26.0.1] QA Override: force disable_sell = False")
     config["disable_buy"] = False
     config["disable_sell"] = False
-    if "disable_buy" in config and config["disable_buy"] is not False:
-        print("[Patch v26.0.1] QA Override: force disable_buy = False")
-        config["disable_buy"] = False
-    if "disable_sell" in config and config["disable_sell"] is not False:
-        print("[Patch v26.0.1] QA Override: force disable_sell = False")
-        config["disable_sell"] = False
     assert not config.get("disable_buy", False), "QA BLOCK: disable_buy=True not allowed"
     assert not config.get("disable_sell", False), "QA BLOCK: disable_sell=True not allowed"
     return generate_signals_v8_0(df, config=config)
@@ -968,8 +967,15 @@ def generate_signals_v12_0(df: pd.DataFrame, config: dict | None = None) -> pd.D
     [Patch v26.0.1] Multi-pattern signal generator - *unblock* buy/sell every signal
     """
     config = config or {}
+    # QA Guard: always force both sides open
+    if config.get("disable_buy", None) is not False:
+        print("[Patch v26.0.1] QA Override: force disable_buy = False [v12.0]")
+    if config.get("disable_sell", None) is not False:
+        print("[Patch v26.0.1] QA Override: force disable_sell = False [v12.0]")
     config["disable_buy"] = False
     config["disable_sell"] = False
+    assert not config.get("disable_buy", False), "QA BLOCK: disable_buy=True not allowed"
+    assert not config.get("disable_sell", False), "QA BLOCK: disable_sell=True not allowed"
     # เดิม...
     # [Patch v12.3.4] ✅ Entry Score Filter (TP2 Potential only)
     df = df.copy()


### PR DESCRIPTION
## Summary
- ปรับ generate_signals และ generate_signals_v12_0 ให้ตรวจค่าจาก config ก่อนบังคับเปิดฝั่ง BUY/SELL พร้อมแสดง log
- อัปเดต AGENTS.md และ changelog.md
- ทดสอบชุด pytest ครบถ้วน

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b41d726d883259dfef2c57a3b70a8