### PR TITLE
Add QA ForceEntry system

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -734,3 +734,6 @@
 ### 2026-01-28
 - [Patch v27.0.0] Oversample TP2, Adaptive TP2 Guard และ QA Self-Healing
 
+### 2026-01-29
+- [Patch v28.1.0] เพิ่มระบบ QA ForceEntry สำหรับทดสอบเท่านั้น พร้อม config ป้องกันใช้งานใน production
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -714,3 +714,6 @@
 ## 2026-01-28
 - [Patch v27.0.0] Oversample TP2 rows, Adaptive TP2 Guard threshold และ QA Self-Healing
 
+## 2026-01-29
+- [Patch v28.1.0] เพิ่ม ForceEntry System สำหรับ QA/Backtest เท่านั้น และปรับ interface main/autopipeline
+

--- a/nicegold_v5/config.py
+++ b/nicegold_v5/config.py
@@ -198,6 +198,17 @@ SESSION_CONFIG = {
     "NY":     {"gain_z_thresh":  0.03, "tp1_rr_ratio": 1.18, "tp2_rr_ratio": 2.30, "disable_buy": False, "disable_sell": False},
 }
 
+# [Patch v28.1.0] QA ForceEntry Config (for QA/backtest only)
+QA_FORCE_ENTRY_CONFIG = {
+    "force_entry": True,
+    "force_entry_ratio": 0.02,
+    "force_entry_side": "both",        # ["buy", "sell", "both"]
+    "force_entry_session": "all",      # ["Asia", "London", "NY", "all"]
+    "force_entry_type": "all",         # reserved for future use
+    "force_entry_min_orders": 30,
+    "force_entry_seed": 42,
+}
+
 # [Patch HEDGEFUND-NEXT] Compound/OMS parameters
 COMPOUND_MILESTONES = [200, 500, 1000, 2000, 5000]
 KILL_SWITCH_DD = 35
@@ -219,6 +230,7 @@ for _cfg in [
     SNIPER_CONFIG_UNBLOCK,
     SNIPER_CONFIG_PROFIT,
     HEDGEFUND_ENTRY_CONFIG,
+    QA_FORCE_ENTRY_CONFIG,
     AUTOFIX_WFV_CONFIG,
 ]:
     ensure_order_side_enabled(_cfg)

--- a/nicegold_v5/tests/test_autopipeline.py
+++ b/nicegold_v5/tests/test_autopipeline.py
@@ -117,7 +117,7 @@ def test_autopipeline(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr('nicegold_v5.entry.validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
-    monkeypatch.setattr(main, 'generate_signals', lambda df, config=None: df.assign(entry_signal=['long']*len(df)))
+    monkeypatch.setattr(main, 'generate_signals', lambda df, config=None, **kw: df.assign(entry_signal=['long']*len(df)))
 
     def dummy_generate(*a, **k):
         os.makedirs('data', exist_ok=True)
@@ -186,7 +186,7 @@ def test_ai_master_pipeline(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr('nicegold_v5.entry.validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
-    monkeypatch.setattr(main, 'generate_signals', lambda df, config=None: df.assign(entry_signal=['long']*len(df)))
+    monkeypatch.setattr(main, 'generate_signals', lambda df, config=None, **kw: df.assign(entry_signal=['long']*len(df)))
 
     monkeypatch.setattr('nicegold_v5.ml_dataset_m1.generate_ml_dataset_m1', lambda *a, **k: None)
     X_dummy = torch.zeros((1, 10, 7))
@@ -258,7 +258,7 @@ def test_fusion_ai_pipeline(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr('nicegold_v5.entry.validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda df, required_cols=None, min_rows=500: None)
-    monkeypatch.setattr(main, 'generate_signals', lambda df, config=None: df.assign(entry_signal=['long']*len(df)))
+    monkeypatch.setattr(main, 'generate_signals', lambda df, config=None, **kw: df.assign(entry_signal=['long']*len(df)))
     monkeypatch.setattr('nicegold_v5.ml_dataset_m1.generate_ml_dataset_m1', lambda *a, **k: None)
     X_dummy = torch.zeros((1, 10, 7))
     y_dummy = torch.zeros((1, 1))

--- a/nicegold_v5/tests/test_autopipeline_no_torch.py
+++ b/nicegold_v5/tests/test_autopipeline_no_torch.py
@@ -20,7 +20,7 @@ def test_autopipeline_no_torch(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(main, 'parse_timestamp_safe', lambda s, fmt: s)
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda *a, **k: None)
-    monkeypatch.setattr(main, 'generate_signals', lambda df, config=None: df.assign(entry_signal=['long']*len(df)))
+    monkeypatch.setattr(main, 'generate_signals', lambda df, config=None, **kw: df.assign(entry_signal=['long']*len(df)))
     monkeypatch.setattr('nicegold_v5.utils.run_autofix_wfv', lambda df, sim, cfg, n_folds=5: pd.DataFrame({'pnl':[0.0]}))
     plan = {
         'device': 'cpu',

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -535,7 +535,7 @@ def test_run_clean_backtest(monkeypatch, tmp_path):
     })
 
     monkeypatch.setattr(main, 'TRADE_DIR', str(tmp_path))
-    monkeypatch.setattr(main, 'generate_signals', lambda d, config=None: d.assign(entry_signal='buy'))
+    monkeypatch.setattr(main, 'generate_signals', lambda d, config=None, **kw: d.assign(entry_signal='buy'))
     monkeypatch.setattr(main, 'simulate_partial_tp_safe', lambda d: pd.DataFrame({'pnl': [1]}))
     monkeypatch.setattr('nicegold_v5.utils.print_qa_summary', lambda *a, **k: {})
     monkeypatch.setattr('nicegold_v5.utils.export_chatgpt_ready_logs', lambda *a, **k: None)
@@ -570,7 +570,7 @@ def test_run_clean_backtest_thai_date(monkeypatch, tmp_path):
         )
 
     monkeypatch.setattr(main, 'simulate_partial_tp_safe', lambda d: pd.DataFrame({'pnl': [1]}))
-    monkeypatch.setattr(main, 'generate_signals', lambda d, config=None: d.assign(entry_signal='buy'))
+    monkeypatch.setattr(main, 'generate_signals', lambda d, config=None, **kw: d.assign(entry_signal='buy'))
     monkeypatch.setattr('nicegold_v5.utils.print_qa_summary', lambda *a, **k: {})
     monkeypatch.setattr('nicegold_v5.utils.export_chatgpt_ready_logs', lambda *a, **k: None)
 
@@ -604,7 +604,7 @@ def test_run_clean_backtest_lowercase_date(monkeypatch, tmp_path):
         )
 
     monkeypatch.setattr(main, 'simulate_partial_tp_safe', lambda d: pd.DataFrame({'pnl': [1]}))
-    monkeypatch.setattr(main, 'generate_signals', lambda d, config=None: d.assign(entry_signal='buy'))
+    monkeypatch.setattr(main, 'generate_signals', lambda d, config=None, **kw: d.assign(entry_signal='buy'))
     monkeypatch.setattr('nicegold_v5.utils.print_qa_summary', lambda *a, **k: {})
     monkeypatch.setattr('nicegold_v5.utils.export_chatgpt_ready_logs', lambda *a, **k: None)
 
@@ -626,7 +626,7 @@ def test_run_clean_backtest_fallback(monkeypatch, capsys, tmp_path):
         'volume': [100, 100],
     })
 
-    def fake_generate(d, config=None):
+    def fake_generate(d, config=None, **kw):
         return d.assign(entry_signal='buy')
 
     monkeypatch.setattr(main, 'generate_signals', fake_generate)
@@ -655,7 +655,7 @@ def test_run_clean_backtest_signal_guard(monkeypatch, tmp_path):
     })
 
     monkeypatch.setattr(main, 'TRADE_DIR', str(tmp_path))
-    monkeypatch.setattr(main, 'generate_signals', lambda d, config=None: d.assign(entry_signal=[None]*len(d)))
+    monkeypatch.setattr(main, 'generate_signals', lambda d, config=None, **kw: d.assign(entry_signal=[None]*len(d)))
     monkeypatch.setattr('nicegold_v5.utils.print_qa_summary', lambda *a, **k: None)
     monkeypatch.setattr('nicegold_v5.utils.export_chatgpt_ready_logs', lambda *a, **k: None)
 

--- a/nicegold_v5/tests/test_coverage_extra.py
+++ b/nicegold_v5/tests/test_coverage_extra.py
@@ -26,7 +26,7 @@ def test_generate_ml_dataset_alt_path(monkeypatch, tmp_path):
     mod_file = importlib.import_module('nicegold_v5.ml_dataset_m1').__file__
     alt_path = Path(mod_file).parent / 'does_not_exist.csv'
     make_sample_csv(alt_path)
-    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None: df)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
     monkeypatch.setattr('nicegold_v5.exit.simulate_partial_tp_safe', lambda df: pd.DataFrame({'entry_time': df['timestamp'].iloc[:2], 'exit_reason': ['tp2', 'sl']}))
     out_csv = tmp_path / 'out.csv'
     generate_ml_dataset_m1('does_not_exist.csv', str(out_csv))
@@ -39,7 +39,7 @@ def test_generate_ml_dataset_missing_timestamp(tmp_path, monkeypatch):
     csv_path = tmp_path / 'data.csv'
     df.to_csv(csv_path, index=False)
     monkeypatch.setattr('main.M1_PATH', str(csv_path))
-    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None: df)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
     monkeypatch.setattr('nicegold_v5.exit.simulate_partial_tp_safe', lambda df: pd.DataFrame())
     with pytest.raises(KeyError):
         generate_ml_dataset_m1(None, str(tmp_path / 'out.csv'))

--- a/nicegold_v5/tests/test_force_entry.py
+++ b/nicegold_v5/tests/test_force_entry.py
@@ -1,0 +1,23 @@
+import pytest
+import pandas as pd
+from nicegold_v5.tests.test_core_all import sample_df
+from nicegold_v5.entry import generate_signals
+
+
+def test_force_entry_injection():
+    df = sample_df()
+    cfg = {
+        "force_entry": True,
+        "force_entry_ratio": 0.2,
+        "force_entry_side": "buy",
+    }
+    out = generate_signals(df, config=cfg, test_mode=True)
+    assert out["entry_signal"].notnull().sum() >= 10
+
+
+def test_force_entry_production_block():
+    df = sample_df()
+    cfg = {"force_entry": True}
+    with pytest.raises(RuntimeError):
+        generate_signals(df, config=cfg, test_mode=False)
+

--- a/nicegold_v5/tests/test_lstm.py
+++ b/nicegold_v5/tests/test_lstm.py
@@ -131,7 +131,7 @@ def test_generate_ml_dataset_m1(tmp_path, monkeypatch):
     out_dir.mkdir()
     out_csv = out_dir / 'ml_dataset_m1.csv'
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None: df)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
     monkeypatch.setattr(
         'nicegold_v5.exit.simulate_partial_tp_safe',
         lambda df: pd.DataFrame({'entry_time': df['entry_time'].iloc[[10, 20]].astype(str).reset_index(drop=True), 'exit_reason': ['tp2', 'sl']})
@@ -151,7 +151,7 @@ def test_generate_ml_dataset_auto_trade_log(tmp_path, monkeypatch):
     out_dir.mkdir()
     out_csv = out_dir / 'ml_dataset_m1.csv'
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None: df)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
     monkeypatch.setattr(
         'nicegold_v5.exit.simulate_partial_tp_safe',
         lambda df: pd.DataFrame({'entry_time': df['entry_time'], 'exit_reason': ['tp2'] * len(df)})
@@ -169,7 +169,7 @@ def test_train_lstm(tmp_path, monkeypatch):
     out_dir.mkdir()
     out_csv = out_dir / 'ml_dataset_m1.csv'
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None: df)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
     monkeypatch.setattr(
         'nicegold_v5.exit.simulate_partial_tp_safe',
         lambda df: pd.DataFrame({'entry_time': df['entry_time'].iloc[[10, 20]].astype(str).reset_index(drop=True), 'exit_reason': ['tp2', 'sl']})
@@ -200,7 +200,7 @@ def test_generate_ml_dataset_creates_dir(tmp_path, monkeypatch):
     df.to_csv(csv_path, index=False)
     out_csv = tmp_path / 'newdir' / 'ml_dataset_m1.csv'
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None: df)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
     monkeypatch.setattr(
         'nicegold_v5.exit.simulate_partial_tp_safe',
         lambda df: pd.DataFrame({'entry_time': df['entry_time'], 'exit_reason': ['tp2'] * len(df)})

--- a/nicegold_v5/tests/test_optuna_objective_extended.py
+++ b/nicegold_v5/tests/test_optuna_objective_extended.py
@@ -25,7 +25,7 @@ def test_objective_score(monkeypatch):
         "volume": [1.0, 1.0, 1.0],
     })
     tuner.session_folds = {"London": df}
-    monkeypatch.setattr(tuner, "generate_signals", lambda d, config=None: d.assign(entry_signal="buy"))
+    monkeypatch.setattr(tuner, "generate_signals", lambda d, config=None, **kw: d.assign(entry_signal="buy"))
     monkeypatch.setattr(
         tuner,
         "run_backtest",


### PR DESCRIPTION
## Summary
- implement ForceEntry injection logic in `generate_signals`
- update main/autopipeline to pass `test_mode`
- add QA_FORCE_ENTRY_CONFIG
- document patch in AGENTS.md and changelog
- add unit tests for ForceEntry and update existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b528b6a2c8325bd12687b7250c0f0