### PR TITLE
แก้ warnings จาก qa.py

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -774,3 +774,5 @@
 - [Patch v28.3.0] เพิ่ม ForceEntry Stress Test และ QA Audit Log ใน qa.py พร้อมเมนู CLI แบบย่อ
 ### 2026-02-11
 - [Patch v28.2.1] ปรับ main.py เพิ่มฟังก์ชัน QA Robustness Integration และเมนูใหม่
+### 2026-02-12
+- แก้คำเตือน FutureWarning ใน qa.py โดยใช้ `np.nan` แทน `pd.NA` และเติม `.fillna(0.0)`

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -752,3 +752,5 @@
 - [Patch v28.3.0] เพิ่ม qa.py สำหรับ ForceEntry Stress Test และบันทึก QA Audit Log พร้อมปรับเมนู CLI
 ## 2026-02-11
 - [Patch v28.2.1] ปรับ main.py เพิ่มเมนู QA Robustness Integration และฟังก์ชัน stress test
+## 2026-02-12
+- แก้คำเตือน FutureWarning ใน qa.py ระหว่าง unittest

--- a/nicegold_v5/qa.py
+++ b/nicegold_v5/qa.py
@@ -185,7 +185,10 @@ def force_entry_stress_test(
 
     equity = trades_df["pnl"].cumsum()
     peak = equity.cummax()
-    trades_df["drawdown"] = ((peak - equity) / peak.replace(0, pd.NA)).fillna(0)
+    trades_df["drawdown"] = (
+        ((peak - equity) / peak.replace(0, np.nan))
+        .fillna(0.0)
+    )
 
     audit = {
         "run_type": "QA_FORCEENTRY",


### PR DESCRIPTION
## Notes
- แก้ฟังก์ชันคำนวณ drawdown ให้ใช้ `np.nan` และเติม `.fillna(0.0)` ป้องกัน FutureWarning ใน pandas

## Summary
- ปรับปรุง `qa.py` เพื่อไม่ให้เกิดคำเตือนขณะรัน unittest
- อัปเดต AGENTS.md และ changelog.md ตามการเปลี่ยนแปลง

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c1906d0ec83258f292fcfa827a317