### PR TITLE
[Patch QA-FIX] run_production_wfv Open fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -862,6 +862,16 @@ def run_production_wfv():
         from nicegold_v5.ml_dataset_m1 import generate_ml_dataset_m1
         generate_ml_dataset_m1(csv_path=M1_PATH, out_path="data/ml_dataset_m1.csv")
         df = pd.read_csv("data/ml_dataset_m1.csv")
+    # [Patch QA-FIX] Fallback – สร้าง 'Open' ถ้าไม่มีใน dataframe
+    if "Open" not in df.columns:
+        if "open" in df.columns:
+            df["Open"] = df["open"]
+            print("[Patch QA-FIX] สร้างคอลัมน์ 'Open' จาก 'open'")
+        elif "close" in df.columns:
+            df["Open"] = df["close"]
+            print("[Patch QA-FIX] สร้างคอลัมน์ 'Open' จาก 'close' (ไม่มี open)")
+        else:
+            raise ValueError("ไม่พบ 'Open' หรือ 'open' หรือ 'close' ใน DataFrame")
     trades = run_walkforward_backtest(df, features, label_col)
     equity = pd.DataFrame({"equity": trades["pnl"].cumsum() if not trades.empty else []})
     auto_qa_after_backtest(trades, equity, label="ProductionWFV")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -780,3 +780,5 @@
 - [Patch v28.2.1] ปรับ main_menu และ export_audit ใช้งานง่าย รองรับ Audit Log แบบ Enterprise
 ### 2026-02-14
 - [Patch QA-FIX] ปรับ run_production_wfv ให้โหลดข้อมูลและส่งพารามิเตอร์ถูกต้อง พร้อมเพิ่มชุดทดสอบใหม่
+### 2026-02-15
+- [Patch QA-FIX] เพิ่ม fallback คอลัมน์ 'Open' ใน run_production_wfv ป้องกัน KeyError

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -758,3 +758,5 @@
 - [Patch v28.2.1] ปรับเมนู CLI และ export_audit ให้บันทึก Audit Log อัตโนมัติ
 ## 2026-02-14
 - [Patch QA-FIX] แก้ฟังก์ชัน run_production_wfv ให้โหลดข้อมูลครบถ้วนและเพิ่ม unit test coverage
+## 2026-02-15
+- [Patch QA-FIX] เพิ่ม fallback คอลัมน์ 'Open' ใน run_production_wfv ป้องกัน KeyError

--- a/nicegold_v5/tests/test_production_wfv.py
+++ b/nicegold_v5/tests/test_production_wfv.py
@@ -28,6 +28,7 @@ def test_run_production_wfv(monkeypatch):
     called = {}
     def fake_run(df_in, features, label_col):
         called['args'] = (features, label_col)
+        called['cols'] = list(df_in.columns)
         return pd.DataFrame({'pnl': [1.0]})
     monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
@@ -36,3 +37,41 @@ def test_run_production_wfv(monkeypatch):
 
     assert called['args'][1] == 'tp2_hit'
     assert 'qa' in called
+    assert 'Open' in called['cols']
+
+
+def test_run_production_wfv_close_fallback(monkeypatch):
+    main = importlib.import_module('main')
+    df = pd.DataFrame({
+        'timestamp': pd.date_range('2025-01-01', periods=2, freq='min'),
+        'high': [1, 2],
+        'low': [1, 2],
+        'close': [1, 2],
+        'gain_z': [0.0, 0.0],
+        'ema_slope': [0.0, 0.0],
+        'atr': [1.0, 1.0],
+        'rsi': [50, 50],
+        'volume': [100, 100],
+        'entry_score': [0.1, 0.2],
+        'pattern_label': [1, 0],
+        'tp2_hit': [0, 1],
+    })
+    monkeypatch.setattr(main, 'load_csv_safe', lambda p: df)
+    monkeypatch.setattr(main, 'convert_thai_datetime', lambda d: d)
+    monkeypatch.setattr(main, 'parse_timestamp_safe', lambda s, fmt: s)
+    monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
+    monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
+
+    called = {}
+    def fake_run(df_in, features, label_col):
+        called['args'] = (features, label_col)
+        called['cols'] = list(df_in.columns)
+        return pd.DataFrame({'pnl': [1.0]})
+    monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
+    monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
+
+    main.run_production_wfv()
+
+    assert called['args'][1] == 'tp2_hit'
+    assert 'qa' in called
+    assert 'Open' in called['cols']


### PR DESCRIPTION
## Summary
- ป้องกัน KeyError 'Open' ใน `run_production_wfv`
- เพิ่ม unit test ตรวจสอบ fallback จาก 'open' และ 'close'
- อัปเดต AGENTS และ changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c22abe1008325a9f59a98ab930b94