### PR TITLE
[Patch QA-FIX v28.2.2] Ensure timestamp index for WFV dataset

### DIFF
--- a/main.py
+++ b/main.py
@@ -873,6 +873,11 @@ def run_production_wfv():
             print("[Patch QA-FIX v28.2.1] สร้างคอลัมน์ 'Open' จาก 'close' (ไม่มี open ใน ML Dataset)")
         else:
             raise ValueError("[Patch QA-FIX v28.2.1] ❌ ไม่พบ 'Open' หรือ 'open' หรือ 'close' ใน DataFrame")
+    # [Patch QA-FIX v28.2.2] Ensure index is timestamp for WFV
+    if "timestamp" in df.columns and not isinstance(df.index, pd.DatetimeIndex):
+        df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+        df = df.set_index("timestamp")
+        print("[Patch QA-FIX v28.2.2] ตั้ง index เป็น timestamp สำหรับ WFV/ML dataset")
     trades = run_walkforward_backtest(df, features, label_col)
     equity = pd.DataFrame({"equity": trades["pnl"].cumsum() if not trades.empty else []})
     auto_qa_after_backtest(trades, equity, label="ProductionWFV")

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -784,3 +784,5 @@
 - [Patch QA-FIX] เพิ่ม fallback คอลัมน์ 'Open' ใน run_production_wfv ป้องกัน KeyError
 ### 2026-02-16
 - [Patch QA-FIX v28.2.1] ปรับปรุง fallback 'Open' ให้ตรวจสอบแบบไม่สนตัวพิมพ์และเพิ่ม log ระหว่างสร้างคอลัมน์ พร้อมทดสอบกรณีไม่มี open/close
+### 2026-02-17
+- [Patch QA-FIX v28.2.2] ตั้ง index เป็น timestamp หากยังไม่ใช่ DatetimeIndex เพื่อแก้ AttributeError ใน pass_filters

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -762,3 +762,5 @@
 - [Patch QA-FIX] เพิ่ม fallback คอลัมน์ 'Open' ใน run_production_wfv ป้องกัน KeyError
 ## 2026-02-16
 - [Patch QA-FIX v28.2.1] เพิ่มการตรวจสอบคอลัมน์ 'open' หรือ 'close' แบบไม่สนตัวพิมพ์ และ raise ValueError หากไม่มี พร้อมทดสอบเพิ่มเติม
+## 2026-02-17
+- [Patch QA-FIX v28.2.2] ตั้ง index เป็น timestamp หากยังไม่ใช่ DatetimeIndex เพื่อป้องกัน AttributeError ใน pass_filters

--- a/nicegold_v5/tests/test_production_wfv.py
+++ b/nicegold_v5/tests/test_production_wfv.py
@@ -30,6 +30,7 @@ def test_run_production_wfv(monkeypatch):
     def fake_run(df_in, features, label_col):
         called['args'] = (features, label_col)
         called['cols'] = list(df_in.columns)
+        called['index_type'] = isinstance(df_in.index, pd.DatetimeIndex)
         return pd.DataFrame({'pnl': [1.0]})
     monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
@@ -39,6 +40,7 @@ def test_run_production_wfv(monkeypatch):
     assert called['args'][1] == 'tp2_hit'
     assert 'qa' in called
     assert 'Open' in called['cols']
+    assert called['index_type']
 
 
 def test_run_production_wfv_close_fallback(monkeypatch):
@@ -67,6 +69,7 @@ def test_run_production_wfv_close_fallback(monkeypatch):
     def fake_run(df_in, features, label_col):
         called['args'] = (features, label_col)
         called['cols'] = list(df_in.columns)
+        called['index_type'] = isinstance(df_in.index, pd.DatetimeIndex)
         return pd.DataFrame({'pnl': [1.0]})
     monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
@@ -76,6 +79,7 @@ def test_run_production_wfv_close_fallback(monkeypatch):
     assert called['args'][1] == 'tp2_hit'
     assert 'qa' in called
     assert 'Open' in called['cols']
+    assert called['index_type']
 
 
 def test_run_production_wfv_no_open_close(monkeypatch):


### PR DESCRIPTION
## Summary
- set DataFrame index to `timestamp` in `run_production_wfv`
- document new patch in `AGENTS.md` and `changelog.md`
- verify via unit tests that the index is correctly set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c25764fb483258e8532782d41bcd6