### PR TITLE
[Patch QA-FIX v29.2.0] Improve Production WFV trade coverage

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -788,3 +788,5 @@
 - [Patch QA-FIX v28.2.2] ตั้ง index เป็น timestamp หากยังไม่ใช่ DatetimeIndex เพื่อแก้ AttributeError ใน pass_filters
 ### 2026-02-18
 - [Patch QA-FIX v28.2.3] ปรับปรุง run_production_wfv ให้ auto-fix index/dtype/column ครบถ้วนและ export QA log เสมอ
+### 2026-02-19
+- [Patch QA-FIX v29.2.0] เพิ่มฟังก์ชัน `ensure_buy_sell` ตรวจสอบและบังคับเปิดไม้ BUY/SELL ใน Production WFV

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -35,6 +35,7 @@ from .wfv import (
     session_performance,
     streak_summary,
     build_trade_log,
+    ensure_buy_sell,
 )
 from .config import ENTRY_CONFIG_PER_FOLD
 from .optuna_tuner import start_optimization, objective

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -766,3 +766,5 @@
 - [Patch QA-FIX v28.2.2] ตั้ง index เป็น timestamp หากยังไม่ใช่ DatetimeIndex เพื่อป้องกัน AttributeError ใน pass_filters
 ## 2026-02-18
 - [Patch QA-FIX v28.2.3] ปรับปรุง run_production_wfv ให้แก้ index/dtype/column อัตโนมัติและบันทึก QA log ทุกกรณี
+## 2026-02-19
+- [Patch QA-FIX v29.2.0] เพิ่มฟังก์ชัน ensure_buy_sell ป้องกัน session หรือ fold ที่ไม่มีฝั่ง BUY/SELL

--- a/nicegold_v5/tests/test_ensure_buy_sell.py
+++ b/nicegold_v5/tests/test_ensure_buy_sell.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from nicegold_v5.wfv import ensure_buy_sell
+
+
+def test_ensure_buy_sell_skip():
+    df = pd.DataFrame({'Open': [1, 2]})
+    trades = pd.DataFrame({'side': ['buy', 'sell']})
+    result = ensure_buy_sell(trades, df, lambda d, percentile_threshold=75: trades)
+    assert len(result) == 2
+
+
+def test_ensure_buy_sell_force(monkeypatch):
+    df = pd.DataFrame({'Open': [1, 2]})
+    calls = {'cnt': 0}
+
+    def fake_sim(data, percentile_threshold=75):
+        calls['cnt'] += 1
+        if percentile_threshold == 75:
+            return pd.DataFrame({'side': ['buy']})
+        return pd.DataFrame({'side': ['buy', 'sell']})
+
+    trades = pd.DataFrame({'side': ['buy']})
+    result = ensure_buy_sell(trades, df, fake_sim)
+    assert {'buy', 'sell'} <= set(result['side'])
+    assert calls['cnt'] >= 1

--- a/nicegold_v5/tests/test_production_wfv.py
+++ b/nicegold_v5/tests/test_production_wfv.py
@@ -27,11 +27,11 @@ def test_run_production_wfv(monkeypatch):
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
 
     called = {}
-    def fake_run(df_in, features, label_col):
+    def fake_run(df_in, features, label_col, **kw):
         called['args'] = (features, label_col)
         called['cols'] = list(df_in.columns)
         called['index_type'] = isinstance(df_in.index, pd.DatetimeIndex)
-        return pd.DataFrame({'pnl': [1.0]})
+        return pd.DataFrame({'pnl': [1.0], 'side': ['buy']})
     monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
 
@@ -66,11 +66,11 @@ def test_run_production_wfv_close_fallback(monkeypatch):
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
 
     called = {}
-    def fake_run(df_in, features, label_col):
+    def fake_run(df_in, features, label_col, **kw):
         called['args'] = (features, label_col)
         called['cols'] = list(df_in.columns)
         called['index_type'] = isinstance(df_in.index, pd.DatetimeIndex)
-        return pd.DataFrame({'pnl': [1.0]})
+        return pd.DataFrame({'pnl': [1.0], 'side': ['buy']})
     monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
 
@@ -104,6 +104,7 @@ def test_run_production_wfv_no_open_close(monkeypatch):
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
     called = {}
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
+    monkeypatch.setattr(main, 'run_walkforward_backtest', lambda *a, **k: pd.DataFrame({'pnl':[0.0], 'side':['buy']}))
 
     main.run_production_wfv()
 


### PR DESCRIPTION
## Summary
- guarantee BUY and SELL trades for Production WFV
- add `ensure_buy_sell` helper
- integrate helper into production workflow
- update unit tests for new behaviour
- document changes in AGENTS and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c2c611e8483258827fd35f32171ae