### PR TITLE
Patch v29.0.0 – Production Guard

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -793,3 +793,5 @@
 ### 2026-02-20
 - [Patch QA-FIX v28.2.4-6] ปรับ run_production_wfv auto-generate dataset หากไม่พบ 'tp2_hit',
   forward ensure_buy_sell ใน main/wfv/qa และเพิ่ม QA fallback เมื่อไม่มี trade
+### 2026-02-21
+- [Patch v29.0.0] เพิ่ม Production Guard ป้องกัน oversample/force label ในโหมด production และต้องมีไม้ TP1/TP2/SL จริงอย่างน้อย 5 ไม้

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -771,3 +771,5 @@
 ## 2026-02-20
 - [Patch QA-FIX v28.2.4-6] ปรับ run_production_wfv auto-generate dataset หากไม่มี 'tp2_hit',
   forward ensure_buy_sell ในหลายโมดูล และเพิ่ม QA fallback เมื่อ trade log ว่าง
+## 2026-02-21
+- [Patch v29.0.0] เพิ่ม Production Guard ป้องกัน oversample/force label ใน production และบังคับให้ WFV มีไม้ TP1/TP2/SL จริง ≥ 5 ไม้

--- a/nicegold_v5/tests/test_coverage_extra.py
+++ b/nicegold_v5/tests/test_coverage_extra.py
@@ -29,7 +29,7 @@ def test_generate_ml_dataset_alt_path(monkeypatch, tmp_path):
     monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
     monkeypatch.setattr('nicegold_v5.exit.simulate_partial_tp_safe', lambda df: pd.DataFrame({'entry_time': df['timestamp'].iloc[:2], 'exit_reason': ['tp2', 'sl']}))
     out_csv = tmp_path / 'out.csv'
-    generate_ml_dataset_m1('does_not_exist.csv', str(out_csv))
+    generate_ml_dataset_m1('does_not_exist.csv', str(out_csv), mode="qa")
     assert out_csv.exists()
     alt_path.unlink()
 
@@ -42,7 +42,7 @@ def test_generate_ml_dataset_missing_timestamp(tmp_path, monkeypatch):
     monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
     monkeypatch.setattr('nicegold_v5.exit.simulate_partial_tp_safe', lambda df: pd.DataFrame())
     with pytest.raises(KeyError):
-        generate_ml_dataset_m1(None, str(tmp_path / 'out.csv'))
+        generate_ml_dataset_m1(None, str(tmp_path / 'out.csv'), mode="qa")
 
 
 def test_print_qa_summary_no_commission():

--- a/nicegold_v5/tests/test_lstm.py
+++ b/nicegold_v5/tests/test_lstm.py
@@ -144,7 +144,7 @@ def test_generate_ml_dataset_m1(tmp_path, monkeypatch):
         'nicegold_v5.exit.simulate_partial_tp_safe',
         lambda df: pd.DataFrame({'entry_time': df['entry_time'].iloc[[10, 20]].astype(str).reset_index(drop=True), 'exit_reason': ['tp2', 'sl']})
     )
-    generate_ml_dataset_m1(str(csv_path), str(out_csv))
+    generate_ml_dataset_m1(str(csv_path), str(out_csv), mode="qa")
     assert out_csv.exists()
     out_df = pd.read_csv(out_csv)
     assert 'tp2_hit' in out_df.columns
@@ -164,7 +164,7 @@ def test_generate_ml_dataset_auto_trade_log(tmp_path, monkeypatch):
         'nicegold_v5.exit.simulate_partial_tp_safe',
         lambda df: pd.DataFrame({'entry_time': df['entry_time'], 'exit_reason': ['tp2'] * len(df)})
     )
-    generate_ml_dataset_m1(str(csv_path), str(out_csv))
+    generate_ml_dataset_m1(str(csv_path), str(out_csv), mode="qa")
     assert out_csv.exists()
     assert (tmp_path / 'logs' / 'trades_v12_tp1tp2.csv').exists()
 
@@ -182,7 +182,7 @@ def test_train_lstm(tmp_path, monkeypatch):
         'nicegold_v5.exit.simulate_partial_tp_safe',
         lambda df: pd.DataFrame({'entry_time': df['entry_time'].iloc[[10, 20]].astype(str).reset_index(drop=True), 'exit_reason': ['tp2', 'sl']})
     )
-    generate_ml_dataset_m1(str(csv_path), str(out_csv))
+    generate_ml_dataset_m1(str(csv_path), str(out_csv), mode="qa")
     X, y = load_dataset(str(out_csv), seq_len=5)
     class LocalModel(torch.nn.Module):
         def forward(self, x):
@@ -215,5 +215,5 @@ def test_generate_ml_dataset_creates_dir(tmp_path, monkeypatch):
         'nicegold_v5.exit.simulate_partial_tp_safe',
         lambda df: pd.DataFrame({'entry_time': df['entry_time'], 'exit_reason': ['tp2'] * len(df)})
     )
-    generate_ml_dataset_m1(str(csv_path), str(out_csv))
+    generate_ml_dataset_m1(str(csv_path), str(out_csv), mode="qa")
     assert out_csv.exists()

--- a/nicegold_v5/tests/test_ml_dataset_extra.py
+++ b/nicegold_v5/tests/test_ml_dataset_extra.py
@@ -20,7 +20,7 @@ def test_generate_ml_dataset_import_fallback(tmp_path, monkeypatch):
     monkeypatch.setattr('nicegold_v5.exit.simulate_partial_tp_safe', lambda d: pd.DataFrame({'entry_time': d['timestamp'].iloc[:1], 'exit_reason':['tp2']}))
     monkeypatch.chdir(tmp_path)
     out_csv = tmp_path / 'out.csv'
-    generate_ml_dataset_m1(None, str(out_csv))
+    generate_ml_dataset_m1(None, str(out_csv), mode="qa")
     assert out_csv.exists()
 
 
@@ -40,6 +40,6 @@ def test_generate_ml_dataset_oversample(tmp_path, monkeypatch):
     monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda d, config=None, **kw: d)
     monkeypatch.setattr('nicegold_v5.exit.simulate_partial_tp_safe', lambda d: pd.DataFrame({'entry_time': d['entry_time'].iloc[[0]], 'exit_reason':['tp2']}))
     out_csv = tmp_path / 'data' / 'ml_dataset_m1.csv'
-    generate_ml_dataset_m1(str(csv_path), str(out_csv))
+    generate_ml_dataset_m1(str(csv_path), str(out_csv), mode="qa")
     out_df = pd.read_csv(out_csv)
     assert out_df['tp2_hit'].sum() >= int(0.02 * len(out_df))

--- a/nicegold_v5/tests/test_production_wfv.py
+++ b/nicegold_v5/tests/test_production_wfv.py
@@ -31,7 +31,11 @@ def test_run_production_wfv(monkeypatch):
         called['args'] = (features, label_col)
         called['cols'] = list(df_in.columns)
         called['index_type'] = isinstance(df_in.index, pd.DatetimeIndex)
-        return pd.DataFrame({'pnl': [1.0], 'side': ['buy']})
+        return pd.DataFrame({
+            'pnl': [1.0] * 5,
+            'side': ['buy'] * 5,
+            'exit_reason': ['tp1'] * 5,
+        })
     monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
 
@@ -70,7 +74,11 @@ def test_run_production_wfv_close_fallback(monkeypatch):
         called['args'] = (features, label_col)
         called['cols'] = list(df_in.columns)
         called['index_type'] = isinstance(df_in.index, pd.DatetimeIndex)
-        return pd.DataFrame({'pnl': [1.0], 'side': ['buy']})
+        return pd.DataFrame({
+            'pnl': [1.0] * 5,
+            'side': ['buy'] * 5,
+            'exit_reason': ['tp1'] * 5,
+        })
     monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
 
@@ -104,7 +112,7 @@ def test_run_production_wfv_no_open_close(monkeypatch):
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
     called = {}
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
-    monkeypatch.setattr(main, 'run_walkforward_backtest', lambda *a, **k: pd.DataFrame({'pnl':[0.0], 'side':['buy']}))
+    monkeypatch.setattr(main, 'run_walkforward_backtest', lambda *a, **k: pd.DataFrame({'pnl':[0.0]*5, 'side':['buy']*5, 'exit_reason':['tp2']*5}))
 
     main.run_production_wfv()
 
@@ -136,7 +144,7 @@ def test_run_production_wfv_auto_dataset(monkeypatch):
     gen_called = {}
     monkeypatch.setattr('nicegold_v5.ml_dataset_m1.generate_ml_dataset_m1', lambda *a, **k: gen_called.setdefault('called', True))
     monkeypatch.setattr(pd, 'read_csv', lambda p: df.assign(tp2_hit=[0, 1]))
-    monkeypatch.setattr(main, 'run_walkforward_backtest', lambda *a, **k: pd.DataFrame({'pnl':[0.0], 'side':['buy']}))
+    monkeypatch.setattr(main, 'run_walkforward_backtest', lambda *a, **k: pd.DataFrame({'pnl':[0.0]*5, 'side':['buy']*5, 'exit_reason':['tp1']*5}))
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda *a, **k: None)
 
     main.run_production_wfv()


### PR DESCRIPTION
## Notes
- Added production guard logic to block oversample in production and ensure real trades exist

## Summary
- introduce `mode` argument in `generate_ml_dataset_m1` with production guard
- call dataset generator with production mode in `run_production_wfv`
- block dummy WFV results when no real TP/SL trades
- update tests for new logic and update docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c41cb27048325b9a1474abd4c48a9