### PR TITLE
[Patch QA-FIX v28.2.7] ensure_buy_sell dynamic param

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -797,3 +797,5 @@
 - [Patch v29.0.0] เพิ่ม Production Guard ป้องกัน oversample/force label ในโหมด production และต้องมีไม้ TP1/TP2/SL จริงอย่างน้อย 5 ไม้
 ### 2026-02-22
 - [Patch v28.2.6] Fix TP2 Missing – Inject Fallback TP2 ใน ML dataset และใช้ ensure_buy_sell ใน generate_ml_dataset_m1
+### 2026-02-23
+- [Patch QA-FIX v28.2.7] ปรับ ensure_buy_sell เรียก simulate_fn แบบ dynamic หากไม่รองรับ percentile_threshold

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -775,3 +775,5 @@
 - [Patch v29.0.0] เพิ่ม Production Guard ป้องกัน oversample/force label ใน production และบังคับให้ WFV มีไม้ TP1/TP2/SL จริง ≥ 5 ไม้
 ## 2026-02-22
 - [Patch v28.2.6] แก้ generate_ml_dataset_m1 เมื่อไม่มี TP2 จริงด้วยการ inject TP2 5 จุด และใช้ ensure_buy_sell ป้องกัน trade log ว่าง
+## 2026-02-23
+- [Patch QA-FIX v28.2.7] ensure_buy_sell เช็ค parameter ก่อนส่ง percentile_threshold เพื่อกัน TypeError

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -60,10 +60,14 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv", mod
     from nicegold_v5.entry import generate_signals
     from nicegold_v5.exit import simulate_partial_tp_safe
     from nicegold_v5.wfv import ensure_buy_sell
+    import inspect  # [Patch QA-FIX v28.2.7] dynamic fallback param check
 
     df_signals = generate_signals(df.copy(), config=SNIPER_CONFIG_ULTRA_OVERRIDE)
     trade_df = simulate_partial_tp_safe(df_signals)
-    trade_df = ensure_buy_sell(trade_df, df_signals, simulate_partial_tp_safe)
+    if "percentile_threshold" in inspect.signature(simulate_partial_tp_safe).parameters:
+        trade_df = ensure_buy_sell(trade_df, df_signals, lambda d: simulate_partial_tp_safe(d, percentile_threshold=1))
+    else:
+        trade_df = ensure_buy_sell(trade_df, df_signals, simulate_partial_tp_safe)
     os.makedirs("logs", exist_ok=True)
     trade_df.to_csv(trade_log_path, index=False)
     print("[Patch v28.2.6] ✅ Trade log saved →", trade_log_path)

--- a/nicegold_v5/tests/test_ensure_buy_sell.py
+++ b/nicegold_v5/tests/test_ensure_buy_sell.py
@@ -23,3 +23,17 @@ def test_ensure_buy_sell_force(monkeypatch):
     result = ensure_buy_sell(trades, df, fake_sim)
     assert {'buy', 'sell'} <= set(result['side'])
     assert calls['cnt'] >= 1
+
+
+def test_ensure_buy_sell_no_percentile():
+    df = pd.DataFrame({'Open': [1, 2]})
+    calls = {'cnt': 0}
+
+    def fake_sim(data):
+        calls['cnt'] += 1
+        return pd.DataFrame({'side': ['buy', 'sell']})
+
+    trades = pd.DataFrame({'side': ['buy']})
+    result = ensure_buy_sell(trades, df, fake_sim)
+    assert {'buy', 'sell'} <= set(result['side'])
+    assert calls['cnt'] >= 1

--- a/nicegold_v5/wfv.py
+++ b/nicegold_v5/wfv.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import inspect  # [Patch QA-FIX v28.2.7] dynamic fallback param check
 from sklearn.model_selection import TimeSeriesSplit
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.pipeline import Pipeline
@@ -272,7 +273,10 @@ def ensure_buy_sell(trades_df: pd.DataFrame, df: pd.DataFrame, simulate_fn) -> p
         return trades_df
 
     print("[Patch QA-FIX] ไม่มี BUY/SELL ครบ – ยิง ultra-relax config")
-    trades_df2 = simulate_fn(df, percentile_threshold=1)
+    if "percentile_threshold" in inspect.signature(simulate_fn).parameters:
+        trades_df2 = simulate_fn(df, percentile_threshold=1)
+    else:
+        trades_df2 = simulate_fn(df)
     sides2 = trades_df2.get("side", trades_df2.get("type", pd.Series(dtype=str))).str.lower()
     has_buy2 = "buy" in sides2.values
     has_sell2 = "sell" in sides2.values


### PR DESCRIPTION
## Summary
- avoid TypeError when `ensure_buy_sell` calls a simulate function without `percentile_threshold`
- check the function signature using `inspect`
- update `generate_ml_dataset_m1` to call `ensure_buy_sell` safely
- add unit test for no-percentile case
- update patch notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c4b7ba87c8325ad9087e494e557bb