### PR TITLE
[Patch v28.2.8] handle invalid entry_time

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -799,3 +799,5 @@
 - [Patch v28.2.6] Fix TP2 Missing – Inject Fallback TP2 ใน ML dataset และใช้ ensure_buy_sell ใน generate_ml_dataset_m1
 ### 2026-02-23
 - [Patch QA-FIX v28.2.7] ปรับ ensure_buy_sell เรียก simulate_fn แบบ dynamic หากไม่รองรับ percentile_threshold
+### 2026-02-24
+- [Patch v28.2.8] แก้ generate_ml_dataset_m1 แปลง entry_time แบบปลอดภัย `errors="coerce"` และกรอง NaT ก่อน map TP2

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -777,3 +777,5 @@
 - [Patch v28.2.6] แก้ generate_ml_dataset_m1 เมื่อไม่มี TP2 จริงด้วยการ inject TP2 5 จุด และใช้ ensure_buy_sell ป้องกัน trade log ว่าง
 ## 2026-02-23
 - [Patch QA-FIX v28.2.7] ensure_buy_sell เช็ค parameter ก่อนส่ง percentile_threshold เพื่อกัน TypeError
+## 2026-02-24
+- [Patch v28.2.8] แก้ generate_ml_dataset_m1 ให้ parse `entry_time` แบบปลอดภัยและกรอง NaT ก่อนคำนวณ tp2_hit

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -73,7 +73,9 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv", mod
     print("[Patch v28.2.6] ✅ Trade log saved →", trade_log_path)
 
     trades = pd.read_csv(trade_log_path)
-    trades["entry_time"] = pd.to_datetime(trades["entry_time"])
+    # [Patch v28.2.8] บาง trade อาจมี entry_time เป็น '0' จาก ensure_buy_sell – แปลงแบบปลอดภัย
+    trades["entry_time"] = pd.to_datetime(trades["entry_time"], errors="coerce")
+    trades = trades.dropna(subset=["entry_time"])
     # [Patch v24.1.1] 🛠️ Ensure 'entry_score', 'gain_z' columns exist in trades
     if "entry_score" not in trades.columns:
         trades["entry_score"] = 1.0

--- a/nicegold_v5/tests/test_ml_dataset_extra.py
+++ b/nicegold_v5/tests/test_ml_dataset_extra.py
@@ -6,7 +6,7 @@ from nicegold_v5.ml_dataset_m1 import generate_ml_dataset_m1
 
 def test_generate_ml_dataset_import_fallback(tmp_path, monkeypatch):
     df = pd.DataFrame({
-        'timestamp': pd.date_range('2025-01-01', periods=20, freq='min'),
+        'timestamp': pd.date_range('2025-01-01', periods=200, freq='min'),
         'open': 1,
         'high': 1,
         'low': 1,
@@ -64,3 +64,24 @@ def test_generate_ml_dataset_prod_fallback(tmp_path, monkeypatch):
     generate_ml_dataset_m1(str(csv_path), str(out_csv), mode='production')
     out_df = pd.read_csv(out_csv)
     assert out_df['tp2_hit'].sum() > 0
+
+
+def test_generate_ml_dataset_entry_time_zero(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        'timestamp': pd.date_range('2025-01-01', periods=200, freq='min'),
+        'open': 1,
+        'high': 1,
+        'low': 1,
+        'close': 1,
+        'volume': 1,
+    })
+    csv_path = tmp_path / 'XAUUSD_M1.csv'
+    df.to_csv(csv_path, index=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda d, config=None, **kw: d)
+    monkeypatch.setattr('nicegold_v5.exit.simulate_partial_tp_safe', lambda d, percentile_threshold=75: pd.DataFrame({'entry_time': ['0'], 'exit_reason': ['tp2']}))
+    monkeypatch.setattr('nicegold_v5.wfv.ensure_buy_sell', lambda trades_df, df, fn: trades_df)
+    out_csv = tmp_path / 'out_zero' / 'ml_dataset_m1.csv'
+    generate_ml_dataset_m1(str(csv_path), str(out_csv), mode='production')
+    out_df = pd.read_csv(out_csv)
+    assert len(out_df) > 0


### PR DESCRIPTION
## Summary
- parse `entry_time` with `errors="coerce"` in `generate_ml_dataset_m1`
- drop trades with invalid entry time before mapping TP2 hits
- add regression test for dummy entry time
- update agents and changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c4eff80b083258bdd7961e49c0f00