### PR TITLE
Implement TP2 mock injection for QA

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -811,3 +811,5 @@
 - [Patch v28.4.0] บังคับ ultra force entry ใน generate_ml_dataset_m1 หากยังไม่มี TP2 ครบ 10 จุด
 ### 2026-02-29
 - [Patch v28.4.1] Inject TP2 label ใน QA/DEV หากยังไม่มี TP2 ครบ 10 จุดหลัง ultra force entry
+### 2026-03-01
+- [Patch v28.4.2] Inject mock TP2 trades เมื่อ trade log ยังมี TP2 ไม่ถึง 10 ไม้ (QA/DEV เท่านั้น)

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -790,3 +790,5 @@
 - [Patch v28.4.0] เพิ่ม ultra force entry fallback ใน generate_ml_dataset_m1 เพื่อบังคับให้มี TP1/TP2/SL จริงเสมอ
 ## 2026-02-29
 - [Patch v28.4.1] บังคับ inject TP2 labels ใน QA/DEV หากยังไม่มี TP2 ครบ 10 จุดหลัง ultra force entry
+## 2026-03-01
+- [Patch v28.4.2] เพิ่มการ inject mock TP2 ลง trade log หากยังมี TP2 ไม่ถึง 10 ไม้ (เฉพาะ QA/DEV)


### PR DESCRIPTION
## Notes
- Added mock TP2 trade injection to guarantee at least 10 TP2 hits when QA/DEV runs
- New unit test verifies dataset creation when no trades exist
- Updated AGENTS.md and changelog.md

## Summary
- enhance `generate_ml_dataset_m1` with QA-only mock TP2 injection
- record change in AGENTS and changelog
- expanded `test_ml_dataset_extra` with mock TP2 scenario

All tests pass:
```
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_683c691b35ec83259578e869ce20e9e8