### PR TITLE
ปรับปรุง unit test

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -813,3 +813,5 @@
 - [Patch v28.4.1] Inject TP2 label ใน QA/DEV หากยังไม่มี TP2 ครบ 10 จุดหลัง ultra force entry
 ### 2026-03-01
 - [Patch v28.4.2] Inject mock TP2 trades เมื่อ trade log ยังมี TP2 ไม่ถึง 10 ไม้ (QA/DEV เท่านั้น)
+### 2026-03-02
+- [Patch v28.4.3] แก้ FutureWarning การ concat DataFrame ว่างใน generate_ml_dataset_m1 และลดจำนวนคำเตือนระหว่างทดสอบ

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -792,3 +792,5 @@
 - [Patch v28.4.1] บังคับ inject TP2 labels ใน QA/DEV หากยังไม่มี TP2 ครบ 10 จุดหลัง ultra force entry
 ## 2026-03-01
 - [Patch v28.4.2] เพิ่มการ inject mock TP2 ลง trade log หากยังมี TP2 ไม่ถึง 10 ไม้ (เฉพาะ QA/DEV)
+## 2026-03-02
+- [Patch v28.4.3] แก้ FutureWarning การ concat DataFrame ว่างใน generate_ml_dataset_m1 เพื่อลดคำเตือนระหว่าง pytest

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -162,7 +162,11 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv", mod
             if "entry_price" in mock_trade:
                 mock_trade["tp2_price"] = mock_trade.get("entry_price", 0) + 1
             mock_trades.append(mock_trade)
-        trade_df = pd.concat([trade_df, pd.DataFrame(mock_trades)], ignore_index=True)
+        new_trades_df = pd.DataFrame(mock_trades)
+        if trade_df.empty:
+            trade_df = new_trades_df.copy()
+        else:
+            trade_df = pd.concat([trade_df, new_trades_df], ignore_index=True)
         print(f"[ADA-BI] ✅ Injected {n_force} mock TP2 orders (QA/DEV only).")
         tp2_count = (trade_df.get("exit_reason") == "tp2").sum()
     if "percentile_threshold" in inspect.signature(simulate_partial_tp_safe).parameters:
@@ -175,7 +179,9 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv", mod
 
     trades = pd.read_csv(trade_log_path)
     # [Patch v28.2.8] บาง trade อาจมี entry_time เป็น '0' จาก ensure_buy_sell – แปลงแบบปลอดภัย
-    trades["entry_time"] = pd.to_datetime(trades["entry_time"], errors="coerce")
+    trades["entry_time"] = pd.to_datetime(
+        trades["entry_time"], format="%Y-%m-%d %H:%M:%S", errors="coerce"
+    )
     trades = trades.dropna(subset=["entry_time"])
     # [Patch v24.1.1] 🛠️ Ensure 'entry_score', 'gain_z' columns exist in trades
     if "entry_score" not in trades.columns:


### PR DESCRIPTION
## Notes
- แก้การ concat DataFrame ว่างใน `generate_ml_dataset_m1` เพื่อลดคำเตือน FutureWarning
- ระบุรูปแบบ `entry_time` ใน `pd.to_datetime` เพื่อลบ UserWarning
- อัพเดต AGENTS.md และ changelog.md ตามแพทช์ v28.4.3

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c6b717f0c83258ec0c41c9ed97451