### PR TITLE
Implement exit variety guard

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -817,3 +817,5 @@
 - [Patch v28.4.3] แก้ FutureWarning การ concat DataFrame ว่างใน generate_ml_dataset_m1 และลดจำนวนคำเตือนระหว่างทดสอบ
 ### 2026-03-03
 - [Patch v29.8.1] Ultra Override QA Mode – Inject signal/exit variety ทันทีใน ML dataset และ entry logic
+### 2026-03-04
+- [Patch v29.9.0] Ultra-Relax Fallback & Exit Variety Guard ใน main.py และ autopipeline

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -797,3 +797,5 @@
 
 ## 2026-03-03
 - [Patch v29.8.1] Ultra Override QA Mode – inject signal/exit variety ครบทุกกรณี
+## 2026-03-04
+- [Patch v29.9.0] เพิ่มระบบเช็ก exit_reason variety และ fallback config หลายระดับใน main.py และ autopipeline

--- a/nicegold_v5/tests/test_autopipeline_no_torch.py
+++ b/nicegold_v5/tests/test_autopipeline_no_torch.py
@@ -21,7 +21,8 @@ def test_autopipeline_no_torch(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda *a, **k: None)
     monkeypatch.setattr(main, 'generate_signals', lambda df, config=None, **kw: df.assign(entry_signal=['long']*len(df)))
-    monkeypatch.setattr('nicegold_v5.utils.run_autofix_wfv', lambda df, sim, cfg, n_folds=5: pd.DataFrame({'pnl':[0.0]}))
+    monkeypatch.setattr('nicegold_v5.utils.run_autofix_wfv', lambda df, sim, cfg, n_folds=5: pd.DataFrame({'pnl':[0.0], 'exit_reason':['tp1']}))
+    monkeypatch.setattr(main, 'check_exit_reason_variety', lambda df: True)
     plan = {
         'device': 'cpu',
         'gpu': 'CPU',

--- a/nicegold_v5/tests/test_main_misc.py
+++ b/nicegold_v5/tests/test_main_misc.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import importlib
+import pandas as pd
 
 
 def test_run_csv_integrity_check():
@@ -27,3 +28,17 @@ def test_maximize_ram(monkeypatch, capsys):
     monkeypatch.setitem(sys.modules, 'psutil', dummy_psutil)
     main.maximize_ram()
     assert 'MAX_RAM_MODE: ON' in capsys.readouterr().out
+
+
+def test_check_exit_reason_variety_pass():
+    main = importlib.import_module('main')
+    df = pd.DataFrame({'exit_reason': ['tp1', 'tp2', 'sl']})
+    assert main.check_exit_reason_variety(df)
+
+
+def test_check_exit_reason_variety_fail(capsys):
+    main = importlib.import_module('main')
+    df = pd.DataFrame({'exit_reason': ['tp1']})
+    assert not main.check_exit_reason_variety(df)
+    out = capsys.readouterr().out
+    assert 'missing' in out

--- a/nicegold_v5/tests/test_production_wfv.py
+++ b/nicegold_v5/tests/test_production_wfv.py
@@ -25,6 +25,7 @@ def test_run_production_wfv(monkeypatch):
     monkeypatch.setattr(main, 'parse_timestamp_safe', lambda s, fmt: s)
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
+    monkeypatch.setattr(main, 'check_exit_reason_variety', lambda df: True)
 
     called = {}
     def fake_run(df_in, features, label_col, **kw):
@@ -68,6 +69,7 @@ def test_run_production_wfv_close_fallback(monkeypatch):
     monkeypatch.setattr(main, 'parse_timestamp_safe', lambda s, fmt: s)
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
+    monkeypatch.setattr(main, 'check_exit_reason_variety', lambda df: True)
 
     called = {}
     def fake_run(df_in, features, label_col, **kw):
@@ -110,6 +112,7 @@ def test_run_production_wfv_no_open_close(monkeypatch):
     monkeypatch.setattr(main, 'parse_timestamp_safe', lambda s, fmt: s)
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
+    monkeypatch.setattr(main, 'check_exit_reason_variety', lambda df: True)
     called = {}
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda t, e, label=None: called.update({'qa': True}))
     monkeypatch.setattr(main, 'run_walkforward_backtest', lambda *a, **k: pd.DataFrame({'pnl':[0.0]*5, 'side':['buy']*5, 'exit_reason':['tp2']*5}))
@@ -140,6 +143,7 @@ def test_run_production_wfv_auto_dataset(monkeypatch):
     monkeypatch.setattr(main, 'parse_timestamp_safe', lambda s, fmt: s)
     monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
     monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
+    monkeypatch.setattr(main, 'check_exit_reason_variety', lambda df: True)
 
     gen_called = {}
     monkeypatch.setattr('nicegold_v5.ml_dataset_m1.generate_ml_dataset_m1', lambda *a, **k: gen_called.setdefault('called', True))


### PR DESCRIPTION
## Summary
- add `check_exit_reason_variety` to verify TP1/TP2/SL variety
- auto fallback across multiple configs in `autopipeline` and `run_production_wfv`
- update tests for new guard logic
- document patch v29.9.0 in AGENTS and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c71e304848325bb2824e2e8922ab1