### PR TITLE
Fix exit variety detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,14 +176,17 @@ def run_smart_fast_qa():
 
 def check_exit_reason_variety(trades_df, require=("tp1", "tp2", "sl")):
     """ตรวจสอบว่า trade log มี exit_reason ครบทุกชนิด"""
-    reasons = trades_df.get("exit_reason", pd.Series(dtype=str)).value_counts()
+    reasons = trades_df.get("exit_reason", pd.Series(dtype=str)).astype(str).str.lower()
+    found = set(reasons)
+    if "tp" in found:
+        found.update({"tp1", "tp2"})
     required = set(require)
-    found = set(reasons.index)
     missing = required - found
     if missing:
-        print(f"[Patch v29.9.0] ❌ Exit variety missing: {missing}")
+        print(f"[Patch v29.9.1] ❌ Exit variety missing: {missing}")
         return False
-    print(f"[Patch v29.9.0] ✅ Exit reason variety: OK ({reasons.to_dict()})")
+    counts = reasons.value_counts().to_dict()
+    print(f"[Patch v29.9.1] ✅ Exit reason variety: OK ({counts})")
     return True
 
 def _run_fold(args):

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -819,3 +819,5 @@
 - [Patch v29.8.1] Ultra Override QA Mode – Inject signal/exit variety ทันทีใน ML dataset และ entry logic
 ### 2026-03-04
 - [Patch v29.9.0] Ultra-Relax Fallback & Exit Variety Guard ใน main.py และ autopipeline
+### 2026-03-05
+- [Patch v29.9.1] แก้ check_exit_reason_variety รองรับค่า 'TP' และอักษรใหญ่

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -799,3 +799,5 @@
 - [Patch v29.8.1] Ultra Override QA Mode – inject signal/exit variety ครบทุกกรณี
 ## 2026-03-04
 - [Patch v29.9.0] เพิ่มระบบเช็ก exit_reason variety และ fallback config หลายระดับใน main.py และ autopipeline
+## 2026-03-05
+- [Patch v29.9.1] ปรับฟังก์ชัน check_exit_reason_variety ให้รองรับค่า 'TP' และอักษรใหญ่

--- a/nicegold_v5/tests/test_main_misc.py
+++ b/nicegold_v5/tests/test_main_misc.py
@@ -36,6 +36,12 @@ def test_check_exit_reason_variety_pass():
     assert main.check_exit_reason_variety(df)
 
 
+def test_check_exit_reason_variety_uppercase():
+    main = importlib.import_module('main')
+    df = pd.DataFrame({'exit_reason': ['TP', 'SL']})
+    assert main.check_exit_reason_variety(df)
+
+
 def test_check_exit_reason_variety_fail(capsys):
     main = importlib.import_module('main')
     df = pd.DataFrame({'exit_reason': ['tp1']})


### PR DESCRIPTION
## Notes
- update check_exit_reason_variety for 'TP' values
- add unit test for uppercase exit reasons
- update changelog and AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c769ab41083259f1a0d14cab4575a