### PR TITLE
Fix WFV class variety handling

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -821,3 +821,5 @@
 - [Patch v29.9.0] Ultra-Relax Fallback & Exit Variety Guard ใน main.py และ autopipeline
 ### 2026-03-05
 - [Patch v29.9.1] แก้ check_exit_reason_variety รองรับค่า 'TP' และอักษรใหญ่
+### 2026-03-06
+- [Patch v29.9.2] แก้ run_walkforward_backtest inject class variety อัตโนมัติเมื่อเหลือคลาสเดียว

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -801,3 +801,6 @@
 - [Patch v29.9.0] เพิ่มระบบเช็ก exit_reason variety และ fallback config หลายระดับใน main.py และ autopipeline
 ## 2026-03-05
 - [Patch v29.9.1] ปรับฟังก์ชัน check_exit_reason_variety ให้รองรับค่า 'TP' และอักษรใหญ่
+
+## 2026-03-06
+- [Patch v29.9.2] แก้ run_walkforward_backtest inject class variety อัตโนมัติเมื่อเหลือคลาสเดียว

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -57,6 +57,12 @@ def sample_wfv_df_close_only():
     df['close'] = range(100, 140)
     return df
 
+# Dataset with single class label
+def sample_wfv_df_single_class():
+    df = sample_wfv_df()
+    df['label'] = 0
+    return df
+
 
 def sample_qa_df():
     dates = pd.date_range('2024-01-01 09:00', periods=100, freq='h')
@@ -413,6 +419,17 @@ def test_run_walkforward_backtest():
     assert not trades.empty
     assert 'r_multiple' in trades.columns
     assert 'session' in trades.columns
+
+def test_run_walkforward_backtest_single_class():
+    df = sample_wfv_df_single_class()
+    trades = wfv.run_walkforward_backtest(
+        df,
+        features=['feat1', 'feat2'],
+        label_col='label',
+        n_folds=2
+    )
+    assert isinstance(trades, pd.DataFrame)
+    assert not trades.empty
 
 
 def test_session_performance():

--- a/nicegold_v5/wfv.py
+++ b/nicegold_v5/wfv.py
@@ -149,9 +149,13 @@ def run_walkforward_backtest(df, features, label_col, side='buy', n_folds=3, per
 
         if y_train.nunique() < 2:
             print(
-                f"[{strategy_name}] Fold {fold + 1}: insufficient class variety – skipping"
+                f"[{strategy_name}] Fold {fold + 1}: insufficient class variety – injecting dummy"
             )
-            continue
+            dummy = df_train.iloc[[0]].copy()
+            dummy[label_col] = 1 - y_train.iloc[0]
+            df_train = pd.concat([df_train, dummy], ignore_index=True)
+            X_train = df_train[features].astype(float)
+            y_train = df_train[label_col]
 
         model = Pipeline(
             [


### PR DESCRIPTION
## Summary
- inject dummy row when `run_walkforward_backtest` encounters only a single class
- test single-class behavior in `test_core_all`
- document new patch in changelog and AGENTS history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c78c56f3083259c8e91100790e24c