### PR TITLE
Patch v30.1.0 Relax production exit-variety requirement

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -828,3 +828,5 @@
   และบังคับ guard โหมด production ต้องมีไม้จริง ≥5 ต่อคลาส
 ### 2026-03-08
 - [Patch v30.0.1] ปรับ run_production_wfv จัดการ RuntimeError จาก generate_ml_dataset_m1 ให้หยุดรันอย่างปลอดภัยและเรียก auto_qa_after_backtest
+### 2026-03-09
+- [Patch v30.1.0] Relax production exit-variety guard ใน generate_ml_dataset_m1 ให้ต้องมี TP1/TP2/SL อย่างน้อย 1 ไม้ต่อคลาส

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -809,3 +809,5 @@
   พร้อม production guard ต้องมี TP1/TP2/SL ไม่น้อยกว่า 5 ไม้
 ## 2026-03-08
 - [Patch v30.0.1] จัดการ RuntimeError จาก generate_ml_dataset_m1 ใน run_production_wfv และเรียก auto_qa_after_backtest แบบนิ่มนวล
+## 2026-03-09
+- [Patch v30.1.0] Relax production exit-variety guard: ต้องมี TP1/TP2/SL อย่างน้อย 1 ไม้ใน generate_ml_dataset_m1

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -188,8 +188,9 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv", mod
 
     if mode == "production":
         counts = trade_df.get("exit_reason", pd.Series(dtype=str)).str.lower().value_counts()
-        if any(counts.get(r, 0) < 5 for r in ("tp1", "tp2", "sl")):
-            raise RuntimeError("[Inject Variety] ❌ ไม่พอ TP1/TP2/SL >=5 ใน production")
+        # [Patch v30.1.0] ลดเกณฑ์ขั้นต่ำจาก 5 → 1 เพื่อไม่ให้ production abort เมื่อข้อมูลน้อย
+        if any(counts.get(r, 0) < 1 for r in ("tp1", "tp2", "sl")):
+            raise RuntimeError("[Inject Variety] ❌ ไม่พอ TP1/TP2/SL >=1 ใน production")
     else:
         trade_df = inject_exit_variety(trade_df)
     ensure_logs_dir("logs")


### PR DESCRIPTION
## Summary
- relaxed production exit-variety requirement to ≥1 trade per exit_reason
- update docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c845c22208325ac29b8c7857973c5