### PR TITLE
Fix split_by_session duplication

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -830,3 +830,5 @@
 - [Patch v30.0.1] ปรับ run_production_wfv จัดการ RuntimeError จาก generate_ml_dataset_m1 ให้หยุดรันอย่างปลอดภัยและเรียก auto_qa_after_backtest
 ### 2026-03-09
 - [Patch v30.1.0] Relax production exit-variety guard ใน generate_ml_dataset_m1 ให้ต้องมี TP1/TP2/SL อย่างน้อย 1 ไม้ต่อคลาส
+### 2026-03-10
+- ปรับ wfv.py ให้ใช้ split_by_session จาก utils เพื่อลดโค้ดซ้ำ และอัพเดต README สรุปตำแหน่งไฟล์ log

--- a/nicegold_v5/README.md
+++ b/nicegold_v5/README.md
@@ -1,3 +1,10 @@
 # NICEXAUUSD
 
 Automated trading research environment for gold (XAUUSD). Includes Sniper strategy with fallback configs.
+
+## ไฟล์ผลลัพธ์และตำแหน่งสำคัญ
+
+* `logs/trades_*` และ `logs/equity_*` – ไฟล์บันทึกผลการเทรดจากฟังก์ชัน walk-forward
+* `logs/resource_plan.json` – แผนการใช้ทรัพยากรจาก `get_resource_plan`
+* `models/model_lstm_tp2.pth` – โมเดล LSTM ที่บันทึกโดย `train_lstm_runner`
+* `data/ml_dataset_m1.csv` – ชุดข้อมูล ML ที่สร้างจาก `generate_ml_dataset_m1`

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -11,6 +11,7 @@ from .entry import (
     generate_entry_signal,
     session_filter,
     trade_log_fields,
+    rsi,
     simulate_trades_with_tp,
     simulate_partial_tp_safe,
 )  # [Patch v10.0] expose latest logic

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -811,3 +811,6 @@
 - [Patch v30.0.1] จัดการ RuntimeError จาก generate_ml_dataset_m1 ใน run_production_wfv และเรียก auto_qa_after_backtest แบบนิ่มนวล
 ## 2026-03-09
 - [Patch v30.1.0] Relax production exit-variety guard: ต้องมี TP1/TP2/SL อย่างน้อย 1 ไม้ใน generate_ml_dataset_m1
+## 2026-03-10
+- ปรับ wfv.py เรียกใช้ split_by_session จาก utils เพื่อลดโค้ดซ้ำ
+- เพิ่มข้อมูลตำแหน่งไฟล์ผลลัพธ์ใน README

--- a/nicegold_v5/wfv.py
+++ b/nicegold_v5/wfv.py
@@ -9,6 +9,8 @@ import matplotlib.pyplot as plt
 import os  # [Patch v12.3.9] Added for export
 from datetime import datetime  # [Patch v12.3.9] Added for timestamp
 
+# ลดการซ้ำซ้อน โดยไม่เก็บโค้ดซ้ำซ้อนในโมดูลนี้
+
 COMMISSION_PER_LOT = 0.10
 SPREAD_VALUE = 0.2
 SLIPPAGE = 0.3
@@ -35,16 +37,11 @@ def auto_entry_config(fold_df: pd.DataFrame) -> dict:
     }
 
 
+
 def split_by_session(df: pd.DataFrame) -> dict:
-    """Split dataframe into session-based subsets"""
-    df = df.copy()
-    df["timestamp"] = pd.to_datetime(df.get("timestamp", pd.date_range("2000-01-01", periods=len(df), freq="h")))
-    df["hour"] = df["timestamp"].dt.hour
-    df = df.set_index("timestamp")
-    asia_df = df[df["hour"].between(3, 7)]
-    london_df = df[df["hour"].between(8, 14)]
-    ny_df = df[df["hour"].between(15, 23)]
-    return {"Asia": asia_df, "London": london_df, "NY": ny_df}
+    """เรียกใช้ฟังก์ชันจาก utils เพื่อแบ่งเซสชัน"""
+    from .utils import split_by_session as util_split_by_session
+    return util_split_by_session(df)
 
 
 def apply_order_costs(entry, sl, tp1, tp2, lot, direction):


### PR DESCRIPTION
## Summary
- refactor `wfv.split_by_session` to call `utils.split_by_session`
- re-export `rsi` via `__init__`
- update README with log file locations
- document the change in AGENTS.md and changelog.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c879073f48325a19bbfa05031c71d