### PR TITLE
Implement patch v30.0.2 for WFV dataset fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -892,12 +892,15 @@ def run_production_wfv():
                 mode="production",
             )
         except RuntimeError as e:
+            # Instead of aborting, log a warning and proceed with an empty 'tp2_hit' column
             print(e)
-            print("[Patch v30.0.1] ❌ Production dataset insufficient – abort WFV")
-            equity = pd.DataFrame({"equity": []})
-            auto_qa_after_backtest(pd.DataFrame(), equity, label="ProductionWFV")
-            return
-        df = pd.read_csv("data/ml_dataset_m1.csv")
+            print(
+                "[Patch v30.0.2] ⚠️ Production dataset insufficient – inserting tp2_hit=0 and continuing WFV"
+            )
+            df["tp2_hit"] = 0
+        else:
+            # Reload ML dataset normally if no exception
+            df = pd.read_csv("data/ml_dataset_m1.csv")
         print(
             f"[Patch QA-FIX v28.2.4] ✅ Reloaded ML dataset – columns: {df.columns.tolist()}"
         )

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -841,3 +841,7 @@
 ### 2026-03-13
 - [Patch v31.2.0] เพิ่ม ForceEntry logic ใน generate_signals_v12_0 สำหรับ QA/dev
 
+### 2026-03-14
+- [Patch v30.0.2] ปรับ run_production_wfv ไม่ abort เมื่อ generate_ml_dataset_m1 ไม่พอ trade
+  แต่ใส่คอลัมน์ tp2_hit=0 แล้วรัน WFV ต่อ
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -824,3 +824,7 @@
 ## 2026-03-13
 - [Patch v31.2.0] เพิ่มตรรกะ ForceEntry เต็มรูปแบบใน `generate_signals_v12_0` สำหรับโหมดทดสอบ
 
+## 2026-03-14
+- [Patch v30.0.2] run_production_wfv ไม่หยุดเมื่อ ML dataset ไม่พอ trade แต่สร้างคอลัมน์
+  tp2_hit=0 แล้วดำเนิน WFV ต่อไป
+

--- a/nicegold_v5/ml_dataset_m1.py
+++ b/nicegold_v5/ml_dataset_m1.py
@@ -191,9 +191,13 @@ def generate_ml_dataset_m1(csv_path=None, out_path="data/ml_dataset_m1.csv", mod
     # [Patch v31.1.0] Production: never abort, always inject missing exit-types
     if mode == "production":
         if missing:
-            print(f"[Patch v31.1.0] ⚠️ Production exit-variety insufficient ({missing}), injecting dummy trades.")
-            trade_df = inject_exit_variety(trade_df)
+            print(
+                f"[Patch v31.1.0] ⚠️ Production exit-variety insufficient ({missing}), injecting dummy trades."
+            )
+        # Inject any missing exit-reasons (TP1/TP2/SL) as dummy rows
+        trade_df = inject_exit_variety(trade_df)
     else:
+        # In QA/DEV modes, always inject variety as well
         trade_df = inject_exit_variety(trade_df)
     ensure_logs_dir("logs")
     trade_df.to_csv(trade_log_path, index=False)

--- a/nicegold_v5/tests/test_production_wfv.py
+++ b/nicegold_v5/tests/test_production_wfv.py
@@ -183,8 +183,15 @@ def test_run_production_wfv_insufficient_trades(monkeypatch):
 
     monkeypatch.setattr('nicegold_v5.ml_dataset_m1.generate_ml_dataset_m1', raise_runtime)
     called = {}
+
+    def fake_run(df_in, features, label_col, **kw):
+        called['cols'] = list(df_in.columns)
+        return pd.DataFrame({'pnl': [0.0], 'side': ['buy'], 'exit_reason': ['tp1']})
+
+    monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
     monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda *a, **k: called.setdefault('qa', True))
 
     main.run_production_wfv()
 
+    assert 'tp2_hit' in called['cols']
     assert called.get('qa')


### PR DESCRIPTION
## Notes
- สนทนาภาษาไทยตามคำสั่งผู้ใช้

## Summary
- ปรับ `generate_ml_dataset_m1` ให้ inject exit variety เสมอในโหมด production
- แก้ `run_production_wfv` ไม่หยุดรันเมื่อ dataset ไม่พอ โดยสร้างคอลัมน์ `tp2_hit=0` แล้วทำงานต่อ
- อัพเดต AGENTS.md และ changelog.md ระบุ Patch v30.0.2
- ปรับชุดทดสอบ `test_run_production_wfv_insufficient_trades`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c93d70d548325b566f24d647b930b