### PR TITLE
Patch v30.0.0 Relax entry thresholds

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -845,3 +845,7 @@
 - [Patch v30.0.2] ปรับ run_production_wfv ไม่ abort เมื่อ generate_ml_dataset_m1 ไม่พอ trade
   แต่ใส่คอลัมน์ tp2_hit=0 แล้วรัน WFV ต่อ
 
+### 2026-03-15
+- [Patch v30.0.0] ลด threshold ใน `generate_signals_v8_0` เพื่อให้เกิด real trades ในแต่ละ fold
+  เพิ่มตัวแปร `sniper_score_min` และปรับ log แสดงเปอร์เซ็นต์สัญญาณที่ถูกบล็อก
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -828,3 +828,7 @@
 - [Patch v30.0.2] run_production_wfv ไม่หยุดเมื่อ ML dataset ไม่พอ trade แต่สร้างคอลัมน์
   tp2_hit=0 แล้วดำเนิน WFV ต่อไป
 
+## 2026-03-15
+- [Patch v30.0.0] ปรับลด threshold ใน `generate_signals_v8_0` ให้เป็นศูนย์และเพิ่มตัวแปร
+  `sniper_score_min` ค่าเริ่มต้น 0.0 เพื่อปลดล็อกการเข้าเทรดใน WFV
+

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -234,11 +234,13 @@ def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.Da
     """ใช้ logic sniper + TP1/TSL แบบล่าสุด (Patch v8.0)."""
     df = df.copy()
 
+    # [Patch v30.0.0] Relaxable Entry Configuration
     config = config or {}
-    gain_z_thresh = config.get("gain_z_thresh", 0.25)
-    ema_slope_min = config.get("ema_slope_min", 0.2)
-    atr_thresh_val = config.get("atr_thresh", 1.0)
-    sniper_risk_score_min = config.get("sniper_risk_score_min", 2.5)  # [Patch v8.1.7]
+    gain_z_thresh = config.get("gain_z_thresh", 0.0)
+    ema_slope_min = config.get("ema_slope_min", 0.0)
+    atr_thresh_val = config.get("atr_thresh", 0.0)
+    sniper_risk_score_min = config.get("sniper_risk_score_min", 2.5)
+    sniper_score_min = config.get("sniper_score_min", 0.0)
     tp_rr_ratio_cfg = config.get("tp_rr_ratio", 4.8)
     volume_ratio = config.get("volume_ratio", 1.0)
     df["entry_signal"] = None
@@ -339,7 +341,7 @@ def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.Da
     sniper_zone = (
         (df["sniper_risk_score"] >= sniper_risk_score_min)
         & (df["gain_z"] > gain_z_thresh)
-        & (df["ema_slope"] > ema_slope_min)
+        & (df["ema_slope"] > ema_slope_min)       # [Patch] จากเดิม > 0.2 เป็น > 0.0
         & df["confirm_zone"]
     )
     sniper_zone |= (
@@ -412,7 +414,7 @@ def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.Da
     print(
         f"[Patch v11.9.5] \u2705 entry_blocked_reason assigned: {df['entry_blocked_reason'].notnull().sum()} filled"
     )
-    blocked_pct = df["entry_signal"].isnull().mean() * 100
+    blocked_pct = df["entry_signal"].isnull().mean() * 100    # [Patch] คำนวณ % ที่ถูก Block หลังลด Threshold
     print(f"[Patch v8.0] Entry Signal Blocked: {blocked_pct:.2f}%")
     return df
 


### PR DESCRIPTION
## Summary
- relax default thresholds in `generate_signals_v8_0`
- document new patch in AGENTS and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c96c38aa88325865329031ef8e599