### PR TITLE
Fix circular import via lazy entry import

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -855,3 +855,6 @@
 ### 2026-03-17
 - ย้าย `adaptive_threshold_dl.py` เข้าไปในแพ็กเกจ `nicegold_v5`
 
+### 2026-03-18
+- ปรับ `__init__.py` ให้ lazy import โมดูล entry ป้องกันวง import ซ้ำ
+

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -1,20 +1,33 @@
-from .entry import (
-    generate_signals_v8_0,
-    generate_signals_v9_0,
-    generate_signals_unblock_v9_1,
-    generate_signals_profit_v10,
-    generate_signals_v11_scalper_m1,
-    generate_signals_v12_0,
-    generate_signals,
-    generate_pattern_signals,
-    apply_tp_logic,
-    generate_entry_signal,
-    session_filter,
-    trade_log_fields,
-    rsi,
-    simulate_trades_with_tp,
-    simulate_partial_tp_safe,
-)  # [Patch v10.0] expose latest logic
+"""NICEGOLD package exports."""
+
+import importlib
+
+_ENTRY_ATTRS = [
+    "generate_signals_v8_0",
+    "generate_signals_v9_0",
+    "generate_signals_unblock_v9_1",
+    "generate_signals_profit_v10",
+    "generate_signals_v11_scalper_m1",
+    "generate_signals_v12_0",
+    "generate_signals",
+    "generate_pattern_signals",
+    "apply_tp_logic",
+    "generate_entry_signal",
+    "session_filter",
+    "trade_log_fields",
+    "rsi",
+    "simulate_trades_with_tp",
+    "simulate_partial_tp_safe",
+]
+
+
+def __getattr__(name):
+    """Lazy-load entry attributes to avoid circular imports."""
+    if name in _ENTRY_ATTRS:
+        entry = importlib.import_module(".entry", __name__)
+        return getattr(entry, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 from .backtester import calc_lot
 from .exit import should_exit
 from .backtester import run_backtest

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -837,3 +837,6 @@
 
 ## 2026-03-17
 - ย้าย `adaptive_threshold_dl.py` เข้าไปในแพ็กเกจ `nicegold_v5`
+## 2026-03-18
+- แก้ปัญหา ImportError วงวนโดย lazy import โมดูล entry ใน `__init__.py`
+

--- a/nicegold_v5/tests/test_imports.py
+++ b/nicegold_v5/tests/test_imports.py
@@ -1,0 +1,6 @@
+import importlib
+
+def test_import_order_no_circular():
+    cfg = importlib.import_module('nicegold_v5.config')
+    entry = importlib.import_module('nicegold_v5.entry')
+    assert hasattr(entry, 'generate_signals')


### PR DESCRIPTION
## Summary
- avoid circular import by lazy-loading entry module
- add regression test for import order
- update AGENTS and changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ca053e3e88325841cc0aed9947ea4