### PR TITLE
Update QA logging and utils

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -860,3 +860,5 @@
 
 ### 2026-03-19
 - [Patch v30.0.0] Align core function signatures, fix imports, and normalize paths
+### 2026-03-20
+- [Patch v32.0.0] ปรับปรุง wfv ให้รองรับ QA_BASE_PATH และบันทึก zero-trade ต่อ fold

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -840,4 +840,7 @@
 ## 2026-03-18
 - แก้ปัญหา ImportError วงวนโดย lazy import โมดูล entry ใน `__init__.py`
 
-\n## 2026-03-19\n- [Patch v30.0.0] Align core function signatures, fix imports, and normalize paths
+## 2026-03-19
+- [Patch v30.0.0] Align core function signatures, fix imports, and normalize paths
+## 2026-03-20
+- [Patch v32.0.0] Updated wfv.ensure_buy_sell to export zero-trade markers and added QA_BASE_PATH constant

--- a/nicegold_v5/tests/test_ensure_buy_sell.py
+++ b/nicegold_v5/tests/test_ensure_buy_sell.py
@@ -5,7 +5,7 @@ from nicegold_v5.wfv import ensure_buy_sell
 def test_ensure_buy_sell_skip():
     df = pd.DataFrame({'Open': [1, 2]})
     trades = pd.DataFrame({'side': ['buy', 'sell']})
-    result = ensure_buy_sell(trades, df, lambda d, percentile_threshold=75: trades)
+    result = ensure_buy_sell(trades, df, lambda d, percentile_threshold=75: trades, outdir=None)
     assert len(result) == 2
 
 
@@ -20,7 +20,7 @@ def test_ensure_buy_sell_force(monkeypatch):
         return pd.DataFrame({'side': ['buy', 'sell']})
 
     trades = pd.DataFrame({'side': ['buy']})
-    result = ensure_buy_sell(trades, df, fake_sim)
+    result = ensure_buy_sell(trades, df, fake_sim, outdir=None)
     assert {'buy', 'sell'} <= set(result['side'])
     assert calls['cnt'] >= 1
 
@@ -34,6 +34,6 @@ def test_ensure_buy_sell_no_percentile():
         return pd.DataFrame({'side': ['buy', 'sell']})
 
     trades = pd.DataFrame({'side': ['buy']})
-    result = ensure_buy_sell(trades, df, fake_sim)
+    result = ensure_buy_sell(trades, df, fake_sim, outdir=None)
     assert {'buy', 'sell'} <= set(result['side'])
     assert calls['cnt'] >= 1

--- a/nicegold_v5/utils.py
+++ b/nicegold_v5/utils.py
@@ -246,6 +246,8 @@ logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 M1_PATH = "data/XAUUSD_M1.csv"
 M15_PATH = "data/XAUUSD_M15.csv"
+QA_BASE_PATH = "logs/qa"
+os.makedirs(QA_BASE_PATH, exist_ok=True)
 
 def ensure_logs_dir(path: str = "logs") -> None:
     """สร้างไดเรกทอรี logs หากยังไม่มี หรือลบไฟล์ที่ชื่อชนกัน"""


### PR DESCRIPTION
## Summary
- add QA_BASE_PATH constant in utils and create directory
- improve `ensure_buy_sell` to export zero-trade markers
- expose logger in `wfv`
- adjust unit tests for new ensure_buy_sell signature
- update AGENTS and changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683cb0aa593883259d0c8163e6c42295