### PR TITLE
Apply v32 patch updates and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,8 @@ from nicegold_v5.wfv import (
 # [Patch QA-FIX v28.2.5] Forward for QA
 from nicegold_v5.wfv import ensure_buy_sell, inject_exit_variety
 from nicegold_v5.utils import ensure_logs_dir
+from nicegold_v5.utils import M1_PATH, TRADE_DIR
+os.makedirs(TRADE_DIR, exist_ok=True)
 
 # Keep backward-compatible name
 run_walkforward_backtest = raw_run
@@ -132,17 +134,7 @@ def calc_lot_risk(capital, atr, risk_pct=1.5):
 def run_csv_integrity_check():
     return True
 
-TRADE_DIR = "logs/trades"
-M1_PATH = os.getenv(
-    "M1_PATH",
-    os.path.join(ROOT_DIR, "nicegold_v5", "XAUUSD_M1.csv"),
-)
-M15_PATH = os.getenv(
-    "M15_PATH",
-    os.path.join(ROOT_DIR, "nicegold_v5", "XAUUSD_M15.csv"),
-)
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-os.makedirs(TRADE_DIR, exist_ok=True)
 
 # [Patch C.2] Enable full RAM mode
 MAX_RAM_MODE = True

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -862,3 +862,7 @@
 - [Patch v30.0.0] Align core function signatures, fix imports, and normalize paths
 ### 2026-03-20
 - [Patch v32.0.0] ปรับปรุง wfv ให้รองรับ QA_BASE_PATH และบันทึก zero-trade ต่อ fold
+### 2026-03-21
+- ปรับ main.py ใช้ M1_PATH/TRADE_DIR จาก utils และสร้างไดเรกทอรีอัตโนมัติ
+- เพิ่ม alias generate_signals_v8_0 และ generate_signals_v12_0 ใน entry.py
+- อัปเดต SESSION_CONFIG ใส่ start/end และปรับ utils.load_data ให้ parse timestamp ปลอดภัย

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -844,3 +844,7 @@
 - [Patch v30.0.0] Align core function signatures, fix imports, and normalize paths
 ## 2026-03-20
 - [Patch v32.0.0] Updated wfv.ensure_buy_sell to export zero-trade markers and added QA_BASE_PATH constant
+## 2026-03-21
+- main.py now imports M1_PATH and TRADE_DIR from utils with auto directory creation
+- entry.py exposes aliases generate_signals_v8_0 and generate_signals_v12_0
+- SESSION_CONFIG includes start/end time fields; utils.load_data parses timestamps safely

--- a/nicegold_v5/config.py
+++ b/nicegold_v5/config.py
@@ -1,4 +1,5 @@
 # config.py – Fold-Based Entry Config
+from datetime import time
 
 ENTRY_CONFIG_PER_FOLD = {
     1: {"gain_z_thresh": -0.05, "ema_slope_min": 0.0001},
@@ -220,9 +221,33 @@ AUTOFIX_WFV_CONFIG = {
 }
 # [Patch v26.0.0] Adaptive Session Config
 SESSION_CONFIG = {
-    "Asia":   {"gain_z_thresh": -0.08, "tp1_rr_ratio": 1.10, "tp2_rr_ratio": 2.0,  "disable_buy": False, "disable_sell": False},
-    "London": {"gain_z_thresh":  0.00, "tp1_rr_ratio": 1.15, "tp2_rr_ratio": 2.15, "disable_buy": False, "disable_sell": False},
-    "NY":     {"gain_z_thresh":  0.03, "tp1_rr_ratio": 1.18, "tp2_rr_ratio": 2.30, "disable_buy": False, "disable_sell": False},
+    "Asia": {
+        "gain_z_thresh": -0.08,
+        "tp1_rr_ratio": 1.10,
+        "tp2_rr_ratio": 2.0,
+        "disable_buy": False,
+        "disable_sell": False,
+        "start": time(1, 0),
+        "end": time(8, 59),
+    },
+    "London": {
+        "gain_z_thresh": 0.00,
+        "tp1_rr_ratio": 1.15,
+        "tp2_rr_ratio": 2.15,
+        "disable_buy": False,
+        "disable_sell": False,
+        "start": time(9, 0),
+        "end": time(16, 59),
+    },
+    "NY": {
+        "gain_z_thresh": 0.03,
+        "tp1_rr_ratio": 1.18,
+        "tp2_rr_ratio": 2.30,
+        "disable_buy": False,
+        "disable_sell": False,
+        "start": time(17, 0),
+        "end": time(23, 59),
+    },
 }
 
 # [Patch v28.1.0] QA ForceEntry Config (for QA/backtest only)

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -1,7 +1,13 @@
 import pandas as pd
 import numpy as np
+from typing import Dict
 from tqdm import tqdm
 from .config import SESSION_CONFIG, HEDGEFUND_ENTRY_CONFIG, THRESHOLD_MODEL_PATH
+
+# [Patch v32.0.0] ✨ เพิ่ม alias ฟังก์ชัน generate_signals_v8_0, generate_signals_v12_0
+def generate_signals_v8_0(df: pd.DataFrame, config: Dict | None = None) -> pd.DataFrame:
+    """[Patch v32.0.0] Core logic version 8.0 alias."""
+    return _generate_signals_v8_0_core(df, config)
 from .adaptive_threshold_dl import predict_thresholds
 
 # --- CONFIG FLAGS (Patch v11.1) ---
@@ -153,7 +159,6 @@ def sanitize_price_columns(df: pd.DataFrame) -> pd.DataFrame:
         print(f"   ▸ {col}: {count} NaN")
     return df
 
-
 def filter_entry_signals(df: pd.DataFrame, config: dict, session: str | None = None) -> pd.DataFrame:
     """Filter entry rows based on config thresholds."""
     df = df.copy()
@@ -248,7 +253,7 @@ def generate_signals_v8_0_adaptive(df: pd.DataFrame, config: dict | None = None)
     return generate_signals_v8_0(df, tmp_cfg)
 
 
-def generate_signals_v8_0(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:
+def _generate_signals_v8_0_core(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:
     """ใช้ logic sniper + TP1/TSL แบบล่าสุด (Patch v8.0)."""
     df = df.copy()
 
@@ -1022,7 +1027,7 @@ def simulate_trades_with_tp(df: pd.DataFrame, sl_distance: float = 5.0):
     return trades, logs
 
 
-def generate_signals_v12_0(
+def _generate_signals_v12_0_core(
     df: pd.DataFrame,
     config: dict | None = None,
     test_mode: bool = False,
@@ -1143,6 +1148,15 @@ def generate_signals_v12_0(
     coverage = df["entry_signal"].notnull().mean() * 100
     print(f"[Patch v12.0] 📊 Entry Signal Coverage: {coverage:.2f}%")
     return df
+
+# [Patch v32.0.0] ✨ alias generate_signals_v12_0
+def generate_signals_v12_0(
+    df: pd.DataFrame,
+    config: Dict | None = None,
+    test_mode: bool = False,
+) -> pd.DataFrame:
+    """[Patch v32.0.0] alias ของ generate_signals_v12_0 core"""
+    return _generate_signals_v12_0_core(df, config=config, test_mode=test_mode)
 
 
 def simulate_partial_tp_safe(df: pd.DataFrame):


### PR DESCRIPTION
## Summary
- import M1_PATH and TRADE_DIR from utils in `main.py`
- add session start/end times in `SESSION_CONFIG`
- expose `generate_signals_v8_0` and `generate_signals_v12_0` aliases
- enhance `utils.load_data` timestamp parsing
- update documentation changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb38c3fe88325ad36f54cfc275879