### PR TITLE
Update wfv QA path imports

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -866,3 +866,5 @@
 - ปรับ main.py ใช้ M1_PATH/TRADE_DIR จาก utils และสร้างไดเรกทอรีอัตโนมัติ
 - เพิ่ม alias generate_signals_v8_0 และ generate_signals_v12_0 ใน entry.py
 - อัปเดต SESSION_CONFIG ใส่ start/end และปรับ utils.load_data ให้ parse timestamp ปลอดภัย
+### 2026-03-22
+- [Patch v32.0.1] นำเข้า QA_BASE_PATH จาก utils ใน wfv.py และส่ง outdir ให้ ensure_buy_sell

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -848,3 +848,5 @@
 - main.py now imports M1_PATH and TRADE_DIR from utils with auto directory creation
 - entry.py exposes aliases generate_signals_v8_0 and generate_signals_v12_0
 - SESSION_CONFIG includes start/end time fields; utils.load_data parses timestamps safely
+## 2026-03-22
+- [Patch v32.0.1] wfv.py imports QA_BASE_PATH from utils and exports zero-trade markers via ensure_buy_sell

--- a/nicegold_v5/utils.py
+++ b/nicegold_v5/utils.py
@@ -27,7 +27,10 @@ from nicegold_v5.entry import (
 )
 from nicegold_v5.backtester import run_backtest
 
-from nicegold_v5.wfv import run_autofix_wfv  # re-export for CLI (Patch v21.2.1)
+
+def run_autofix_wfv(*args, **kwargs):  # re-export for CLI (Patch v21.2.1)
+    from nicegold_v5.wfv import run_autofix_wfv as orig
+    return orig(*args, **kwargs)
 
 
 # [Patch vA.1.0] helper functions for adaptive threshold

--- a/nicegold_v5/wfv.py
+++ b/nicegold_v5/wfv.py
@@ -20,10 +20,16 @@ ORDER_DURATION_MIN = 120
 DEFAULT_RISK_PER_TRADE = 0.01
 INITIAL_CAPITAL = 10000.0
 
+from nicegold_v5.entry import generate_signals_v12_0 as generate_signals
+from nicegold_v5.exit import simulate_partial_tp_safe
+from nicegold_v5.utils import (
+    sanitize_price_columns,
+    convert_thai_datetime,
+    parse_timestamp_safe,
+    QA_BASE_PATH,
+)
 from nicegold_v5.fix_engine import autofix_fold_run, autorisk_adjust, run_self_diagnostic
 
-QA_BASE_PATH = "logs/qa"
-os.makedirs(QA_BASE_PATH, exist_ok=True)
 
 TRADE_DIR = "logs/trades"  # [Patch v12.3.9] Define log dir
 os.makedirs(TRADE_DIR, exist_ok=True)  # [Patch v12.3.9] Ensure log dir exists


### PR DESCRIPTION
## Summary
- import QA_BASE_PATH from `utils` in `wfv.py`
- expose `run_autofix_wfv` lazily to avoid circular import
- document update in changelog and AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb83cc7b08325903b606fdc2a5cdc