### PR TITLE
Loosen TP logic

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -868,3 +868,5 @@
 - อัปเดต SESSION_CONFIG ใส่ start/end และปรับ utils.load_data ให้ parse timestamp ปลอดภัย
 ### 2026-03-22
 - [Patch v32.0.1] นำเข้า QA_BASE_PATH จาก utils ใน wfv.py และส่ง outdir ให้ ensure_buy_sell
+### 2026-03-23
+- [Patch v32.0.2] ปรับ DEFAULT_RR1/DEFAULT_RR2 ใน apply_tp_logic ให้ TP2 ถึงง่ายขึ้น

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -850,3 +850,5 @@
 - SESSION_CONFIG includes start/end time fields; utils.load_data parses timestamps safely
 ## 2026-03-22
 - [Patch v32.0.1] wfv.py imports QA_BASE_PATH from utils and exports zero-trade markers via ensure_buy_sell
+## 2026-03-23
+- [Patch v32.0.2] Lower DEFAULT_RR1/DEFAULT_RR2 in entry.apply_tp_logic for easier TP2

--- a/nicegold_v5/entry.py
+++ b/nicegold_v5/entry.py
@@ -16,11 +16,15 @@ ENABLE_TP1_TP2 = True
 ENABLE_SESSION_FILTER = False
 ENABLE_SIGNAL_LOG = True
 
+# [Patch v32.0.2] 💥 Loosen TP Logic: ลด rr1, rr2 เพื่อให้ TP2 เอื้อมถึงได้ง่ายขึ้น
+DEFAULT_RR1 = 1.2    # จากเดิม 1.5–2.0
+DEFAULT_RR2 = 2.0    # จากเดิม 3.0–5.0
 
-def apply_tp_logic(entry_price: float, direction: str, rr1: float = 1.5, rr2: float = 3.0, sl_distance: float = 5.0) -> tuple[float, float]:
+def apply_tp_logic(entry_price: float, direction: str, rr1: float = 3.0, sl_distance: float = 5.0) -> tuple[float, float]:
     """คำนวณเป้าหมาย TP1/TP2 ตาม Risk Reward"""
-    tp1 = entry_price + rr1 * sl_distance if direction == "buy" else entry_price - rr1 * sl_distance
-    tp2 = entry_price + rr2 * sl_distance if direction == "buy" else entry_price - rr2 * sl_distance
+    # [Patch v32.0.2] ใช้ DEFAULT_RR1, DEFAULT_RR2 แทน rr1*2 เดิม
+    tp1 = entry_price + DEFAULT_RR1 * sl_distance if direction == "buy" else entry_price - DEFAULT_RR1 * sl_distance
+    tp2 = entry_price + DEFAULT_RR2 * sl_distance if direction == "buy" else entry_price - DEFAULT_RR2 * sl_distance
     return tp1, tp2
 
 
@@ -1110,7 +1114,7 @@ def _generate_signals_v12_0_core(
         if pd.notnull(row["entry_signal"]):
             direction = row["entry_signal"]
             sl_dist = row["atr"]
-            tp1, tp2 = apply_tp_logic(row["close"], direction, 1.5, 3.0, sl_dist)
+            tp1, tp2 = apply_tp_logic(row["close"], direction, sl_distance=sl_dist)
             sl = row["close"] - sl_dist if direction == "buy" else row["close"] + sl_dist
 
             df.at[i, "tp1_price"] = tp1

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -1073,9 +1073,9 @@ from nicegold_v5.entry import (
 
 
 def test_apply_tp_logic():
-    tp1, tp2 = apply_tp_logic(100, 'buy', rr1=1.5, rr2=3.0, sl_distance=5)
-    assert tp1 == 107.5
-    assert tp2 == 115.0
+    tp1, tp2 = apply_tp_logic(100, 'buy', sl_distance=5)
+    assert tp1 == 106.0
+    assert tp2 == 110.0
 
 
 def test_generate_entry_signal():


### PR DESCRIPTION
## Notes
- Adjusted default RR1 and RR2 for TP calculation and updated unit tests
- Recorded patch in AGENTS.md and changelog

## Summary
- Introduced `DEFAULT_RR1` and `DEFAULT_RR2` constants in `entry.py`
- Modified `apply_tp_logic` to use these constants
- Updated signal generation to call `apply_tp_logic` with new signature
- Revised unit tests for the new TP calculation
- Documented Patch v32.0.2 in `AGENTS.md` and `changelog.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cba7e3fac8325bbbc9628649006fc