### PR TITLE
[Patch v32.0.3] ปรับ threshold scalper

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -870,3 +870,6 @@
 - [Patch v32.0.1] นำเข้า QA_BASE_PATH จาก utils ใน wfv.py และส่ง outdir ให้ ensure_buy_sell
 ### 2026-03-23
 - [Patch v32.0.2] ปรับ DEFAULT_RR1/DEFAULT_RR2 ใน apply_tp_logic ให้ TP2 ถึงง่ายขึ้น
+
+### 2026-03-24
+- [Patch v32.0.3] ปรับลด threshold ใน generate_signals และ scalper_v11 ให้เทรดง่ายขึ้น

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -852,3 +852,6 @@
 - [Patch v32.0.1] wfv.py imports QA_BASE_PATH from utils and exports zero-trade markers via ensure_buy_sell
 ## 2026-03-23
 - [Patch v32.0.2] Lower DEFAULT_RR1/DEFAULT_RR2 in entry.apply_tp_logic for easier TP2
+
+## 2026-03-24
+- [Patch v32.0.3] Relaxed confirm_zone thresholds and ATR handling in entry.generate_signals and scalper_v11


### PR DESCRIPTION
## Summary
- ปรับค่า gain_z_thresh, ema_slope_min และ atr_thresh ใน `generate_signals_profit_v10`
- คำนวณ `ema_slope` และ `atr` ใหม่ พร้อม fillna
- ผ่อนปรนเกณฑ์ confirm_zone ใน `generate_signals` และ `generate_signals_v11_scalper_m1`
- อัปเดต `AGENTS.md` และ `changelog.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cc1822178832592725a5785f2c9f8