### PR TITLE
Update LSTM runner fallback

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -877,3 +877,5 @@
 - [Patch v32.0.4] simulate_partial_tp_safe รองรับ percentile_threshold และบังคับ TP2 ใน QA
 ### 2026-03-26
 - [Patch v32.0.5] generate_ml_dataset_m1 เปลี่ยนชื่อคอลัมน์ราคาเป็นตัวพิมพ์ใหญ่และเตือนเมื่อไม่มี tp2_hit
+### 2026-03-27
+- ปรับ train_lstm_runner ตรวจสอบการติดตั้ง PyTorch ด้วยตัวแปร TORCH_AVAILABLE และออกจากการเทรนเมื่อไม่มีไลบรารี

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -859,3 +859,5 @@
 - [Patch v32.0.4] simulate_partial_tp_safe now accepts percentile_threshold and injects TP2 trades in QA
 ## 2026-03-26
 - [Patch v32.0.5] generate_ml_dataset_m1 renames price columns to Title-case and warns when 'tp2_hit' missing
+## 2026-03-27
+- Updated train_lstm_runner to gracefully skip training when PyTorch is missing using TORCH_AVAILABLE flag; adjusted unit tests


### PR DESCRIPTION
## Summary
- add TORCH_AVAILABLE flag in `train_lstm_runner`
- skip training when PyTorch is missing and guard on `torch.nn.LSTM`
- update related unit tests
- document patch in AGENTS.md and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d1fcaf7348325a0cd36e5254bf4c5