### PR TITLE
ปรับ optuna_tuner ตรวจสอบคอลัมน์ ML dataset

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -879,3 +879,5 @@
 - [Patch v32.0.5] generate_ml_dataset_m1 เปลี่ยนชื่อคอลัมน์ราคาเป็นตัวพิมพ์ใหญ่และเตือนเมื่อไม่มี tp2_hit
 ### 2026-03-27
 - ปรับ train_lstm_runner ตรวจสอบการติดตั้ง PyTorch ด้วยตัวแปร TORCH_AVAILABLE และออกจากการเทรนเมื่อไม่มีไลบรารี
+### 2026-03-28
+- ปรับ optuna_tuner นำเข้า split_by_session จาก wfv และใช้ logger แจ้งเมื่อ ML dataset ไม่มีคอลัมน์ pattern_label หรือ entry_score

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -861,3 +861,5 @@
 - [Patch v32.0.5] generate_ml_dataset_m1 renames price columns to Title-case and warns when 'tp2_hit' missing
 ## 2026-03-27
 - Updated train_lstm_runner to gracefully skip training when PyTorch is missing using TORCH_AVAILABLE flag; adjusted unit tests
+## 2026-03-28
+- optuna_tuner now imports split_by_session from wfv and logs an error when ML dataset lacks pattern_label or entry_score

--- a/nicegold_v5/optuna_tuner.py
+++ b/nicegold_v5/optuna_tuner.py
@@ -2,7 +2,8 @@ import pandas as pd
 import optuna
 from nicegold_v5.entry import generate_signals
 from nicegold_v5.backtester import run_backtest
-from nicegold_v5.utils import print_qa_summary, split_by_session
+from nicegold_v5.wfv import split_by_session
+from nicegold_v5.utils import print_qa_summary, logger
 
 session_folds: dict[str, pd.DataFrame] = {}
 
@@ -25,6 +26,11 @@ def objective(trial) -> float:
         df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
     if df.empty:
         return -999
+    if "pattern_label" not in df.columns or "entry_score" not in df.columns:
+        logger.error(
+            "Missing columns pattern_label or entry_score in ML dataset → ให้รัน generate_ml_dataset_m1 ก่อน"
+        )
+        return float("inf")
     df = generate_signals(df, config=config)
     trades, equity = run_backtest(df)
 

--- a/nicegold_v5/tests/test_entry_additional.py
+++ b/nicegold_v5/tests/test_entry_additional.py
@@ -151,4 +151,4 @@ def test_optuna_objective_trades_empty(monkeypatch):
         'tp_rr_ratio': 4.5,
         'volume_ratio': 1.0,
     })
-    assert objective(trial) == -999
+    assert objective(trial) == float("inf")

--- a/nicegold_v5/tests/test_optuna_objective_extended.py
+++ b/nicegold_v5/tests/test_optuna_objective_extended.py
@@ -44,3 +44,24 @@ def test_objective_score(monkeypatch):
     })
     score = tuner.objective(trial)
     assert score > 0
+
+
+def test_objective_missing_columns(monkeypatch):
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2025-01-01", periods=2, freq="h"),
+        "close": [1.0, 1.1],
+        "high": [1.0, 1.1],
+        "low": [0.9, 1.0],
+        "volume": [1.0, 1.0],
+    })
+    tuner.session_folds = {"London": df}
+    trial = optuna.trial.FixedTrial({
+        "gain_z_thresh": 0.1,
+        "ema_slope_min": 0.1,
+        "atr_thresh": 0.5,
+        "sniper_risk_score_min": 5.5,
+        "tp_rr_ratio": 4.5,
+        "volume_ratio": 1.0,
+    })
+    result = tuner.objective(trial)
+    assert result == float("inf")


### PR DESCRIPTION
## Summary
- นำเข้า `split_by_session` จาก `wfv` และ `logger` ใน `optuna_tuner`
- เพิ่มการตรวจสอบคอลัมน์ `pattern_label` และ `entry_score`
- ปรับชุดทดสอบให้รองรับค่าผลลัพธ์ใหม่
- อัพเดตเอกสาร AGENTS.md และ changelog.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d231d69f4832592e44002f9511d16