### PR TITLE
Integrate indicator state RLScalper

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -881,3 +881,6 @@
 - ปรับ train_lstm_runner ตรวจสอบการติดตั้ง PyTorch ด้วยตัวแปร TORCH_AVAILABLE และออกจากการเทรนเมื่อไม่มีไลบรารี
 ### 2026-03-28
 - ปรับ optuna_tuner นำเข้า split_by_session จาก wfv และใช้ logger แจ้งเมื่อ ML dataset ไม่มีคอลัมน์ pattern_label หรือ entry_score
+### 2026-03-29
+- [Patch v32.0.6] ปรับ RLScalper ให้รองรับ state-space จาก indicators และสร้าง generate_all_states
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -863,3 +863,6 @@
 - Updated train_lstm_runner to gracefully skip training when PyTorch is missing using TORCH_AVAILABLE flag; adjusted unit tests
 ## 2026-03-28
 - optuna_tuner now imports split_by_session from wfv and logs an error when ML dataset lacks pattern_label or entry_score
+## 2026-03-29
+- [Patch v32.0.6] RLScalper now supports indicator-based state space generation and epsilon-greedy updates
+

--- a/nicegold_v5/tests/test_rl_agent.py
+++ b/nicegold_v5/tests/test_rl_agent.py
@@ -3,12 +3,20 @@ from nicegold_v5.rl_agent import RLScalper
 
 
 def test_rl_training():
-    df = pd.DataFrame({
-        'open': [1, 2, 3, 2, 3],
-        'close': [2, 3, 2, 3, 4],
-    })
-    agent = RLScalper(lr=0.5, gamma=0.9, eps=0.2)
-    q_table = agent.train(df)
+    df = pd.DataFrame(
+        {
+            "open": [1, 2, 3, 2, 3],
+            "close": [2, 3, 2, 3, 4],
+            "gain_z_positive": [True, True, False, True, True],
+            "ema_trend": ["up", "up", "down", "up", "up"],
+        }
+    )
+    indicators = {
+        "gain_z_positive": [True, False],
+        "ema_trend": ["up", "down"],
+    }
+    agent = RLScalper(action_space=["buy", "sell"])
+    q_table = agent.train(df, indicators)
     assert isinstance(q_table, dict)
-    assert len(q_table) > 0
+    assert len(q_table) == len(agent.state_space)
 


### PR DESCRIPTION
## Summary
- enhance `RLScalper` to support indicator based states and epsilon-greedy updates
- update unit tests for RL agent
- document RLScalper changes in `AGENTS.md` and `changelog.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d246e9eb88325b01272ecebf7c249