### PR TITLE
ปรับปรุง exit logic และ unit test

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -903,3 +903,7 @@
   - เพิ่ม Logging, Config via YAML, และ Unit/Integration Tests ครบถ้วน
   - ปรับระดับ Log Level, ลด log ยิบย่อย
   - รองรับ path สัมพัทธ์ (data/, logs/)
+
+### 2026-04-02
+- [Patch v32.0.7] ปรับปรุง detect_session_auto ให้รับ dict หรือ timestamp และปรับช่วงเวลาเป็น 0-7 Asia, 8-14 London, 15-23 NY
+- ปรับ simulate_partial_tp_safe ให้ใช้ logger.warning แทน print และบังคับ QA Inject TP2 ทุกกรณีเมื่อ MFE ถึงครึ่งทาง

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -887,3 +887,7 @@
   - เพิ่ม Logging, Config via YAML, และ Unit/Integration Tests ครบถ้วน
   - ปรับระดับ Log Level, ลด log ยิบย่อย
   - รองรับ path สัมพัทธ์ (data/, logs/)
+
+## 2026-04-02
+- [Patch v32.0.7] Updated detect_session_auto to accept dict or timestamp and adjusted session ranges.
+- simulate_partial_tp_safe now logs warnings for missing columns and forces TP2 injection when MFE crosses 50%.

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -1289,7 +1289,9 @@ def test_detect_session_auto():
     assert detect_session_auto(pd.Timestamp('2025-01-01 04:00')) == 'Asia'
     assert detect_session_auto(pd.Timestamp('2025-01-01 10:00')) == 'London'
     assert detect_session_auto(pd.Timestamp('2025-01-01 16:00')) == 'NY'
-    assert detect_session_auto(pd.Timestamp('2025-01-01 02:00')) == 'Unknown'
+    assert detect_session_auto(pd.Timestamp('2025-01-01 02:00')) == 'Asia'
+    # รองรับ dict input
+    assert detect_session_auto({'timestamp': pd.Timestamp('2025-01-01 20:00')}) == 'NY'
 
 
 def test_simulate_partial_tp_safe_session(monkeypatch):
@@ -1307,7 +1309,7 @@ def test_simulate_partial_tp_safe_session(monkeypatch):
     assert not trades.empty
     assert 'session' in trades.columns
     assert trades['session'].iloc[0] == 'London'
-    assert trades['exit_reason'].iloc[0] in {'tp1', 'sl'}
+    assert trades['exit_reason'].iloc[0] in {'tp1', 'tp2', 'sl'}
 
 
 def test_entry_simulate_partial_tp_safe_basic():


### PR DESCRIPTION
## Notes
- ปรับ detect_session_auto ให้รองรับ timestamp หรือ dict และปรับเวลาเซสชันใหม่
- simulate_partial_tp_safe ใช้ logger แทน print และบังคับ QA Inject TP2 เมื่อถึง threshold
- อัพเดต AGENTS.md และ changelog.md เป็น Patch v32.0.7
- แก้ unit test ให้สอดคล้องกับตรรกะใหม่

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d2f6751b48325b4dddc78a24a6fe1