### PR TITLE
Apply patch v32.1.2 to fix_engine

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -974,3 +974,7 @@
 ### 2026-04-07
 - [Patch v32.1.1] ปรับ fallback force_entry กลับก่อนคำนวณเงื่อนไขและตรวจ param ด้วย inspect
 
+### 2026-04-08
+- [Patch v32.1.2] ปรับปรุง `fix_engine` นำ `ensure_order_side_enabled` เข้า `auto_fix_logic`
+  และปรับ `autorisk_adjust` ให้ใช้ `deepcopy` พร้อมลดเงื่อนไขเหลือเฉพาะ TP rate
+

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -977,3 +977,7 @@
 ## 2026-04-07
 - [Patch v32.1.1] ปรับ fallback force_entry และตรวจพารามิเตอร์ใน predict_thresholds ด้วย inspect
 
+## 2026-04-08
+- [Patch v32.1.2] ปรับปรุง fix_engine ให้เรียกใช้ ensure_order_side_enabled ใน auto_fix_logic
+  และลดเงื่อนไขใน autorisk_adjust ใช้ deepcopy
+

--- a/nicegold_v5/tests/test_core_all.py
+++ b/nicegold_v5/tests/test_core_all.py
@@ -391,8 +391,8 @@ def test_autorisk_adjust():
     summary = {"tp_rate": 0.1, "sl_rate": 0.5, "net_pnl": -1.0}
     new_cfg = autorisk_adjust(cfg, summary)
     assert new_cfg["tp1_rr_ratio"] == 1.2
-    assert new_cfg["atr_multiplier"] == 1.6
-    assert new_cfg["enable_be"] and new_cfg["enable_trailing"] and new_cfg["use_dynamic_tsl"]
+    assert new_cfg["atr_multiplier"] == 1.0
+    assert "enable_be" not in new_cfg
 
 
 def test_run_autofix_wfv(tmp_path):

--- a/nicegold_v5/tests/test_fix_engine.py
+++ b/nicegold_v5/tests/test_fix_engine.py
@@ -59,6 +59,21 @@ def test_auto_fix_logic_exit_variety():
     assert new_cfg['tp1_rr_ratio'] == 1.2
 
 
+def test_auto_fix_logic_enables_order_side():
+    summary = {
+        'tp1_count': 1,
+        'tp2_count': 1,
+        'sl_rate': 0.1,
+        'avg_mfe': 1.0,
+        'avg_duration': 3.0,
+        'net_pnl': 1.0,
+    }
+    config = {'disable_buy': True, 'disable_sell': True}
+    new_cfg = auto_fix_logic(summary, config)
+    assert new_cfg['disable_buy'] is False
+    assert new_cfg['disable_sell'] is False
+
+
 def test_simulate_and_autofix_basic():
     df = pd.DataFrame({'close': [1, 2]})
 


### PR DESCRIPTION
## Summary
- update `fix_engine` to enforce order side safety
- update `autorisk_adjust` logic and patch version comments
- add unit test for order side override
- update existing autorisk_adjust test expectations
- document patch v32.1.2 in `AGENTS.md` and `changelog.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d58ad4b20832587287ffc723aefec