### PR TITLE
Apply vConfig v1.0 defaults

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -15,6 +15,10 @@ sniper_config_q3_tuned:
   force_entry: false
   tp1_pct: 0.7
   tp2_pct: 0.3
+  gain_z_thresh: 0.5  # ยังคงเดิม (Phase Q3 initial)
+  atr_multiplier: 1.0
+  rsi_oversold: 30
+  rsi_overbought: 70
 
 relax_config_q3:
   disable_buy: false
@@ -22,6 +26,20 @@ relax_config_q3:
   force_entry: false
   tp1_pct: 0.6
   tp2_pct: 0.4
+  gain_z_thresh: 0.3
+  atr_multiplier: 0.8
+  rsi_oversold: 35
+  rsi_overbought: 65
+  pattern_whitelist:
+    - inside_bar
+    - bullish_engulfing
+    - bearish_engulfing
+    - hammer
+    - engulfing
+  volume_ratio: 0.8
+  tp_rr_ratio: 1.5
+  sl_distance: 5.0
+  dynamic_lot: false
 
 ultra_override_qa:
   disable_buy: false

--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -1017,3 +1017,8 @@
 ### 2026-04-16
 - [Patch v32.2.1] รองรับคอลัมน์ราคา Titlecase ใน generate_signals_v8_0
   - คัดลอกคอลัมน์ Open/High/Low/Close เป็นตัวพิมพ์เล็กหากยังไม่มี
+
+### 2026-04-17
+- [Patch vConfig v1.0] เพิ่มค่า config ใหม่ใน defaults.yaml
+  - อัพเดต SNIPER_CONFIG_Q3_TUNED และ RELAX_CONFIG_Q3 พร้อมตัวแปร gain_z_thresh,
+    atr_multiplier และ rsi limits

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -1017,3 +1017,8 @@
 ## 2026-04-16
 - [Patch v32.2.1] รองรับคอลัมน์ราคา Titlecase ใน generate_signals_v8_0
 - คัดลอกคอลัมน์ Open/High/Low/Close เป็นตัวพิมพ์เล็กเพื่อหลีกเลี่ยง KeyError
+
+## 2026-04-17
+- [Patch vConfig v1.0] เพิ่มค่า config ใหม่ใน defaults.yaml
+- ปรับ SNIPER_CONFIG_Q3_TUNED และ RELAX_CONFIG_Q3 ให้รองรับ gain_z_thresh,
+  atr_multiplier และ rsi limits

--- a/nicegold_v5/tests/test_config.py
+++ b/nicegold_v5/tests/test_config.py
@@ -6,6 +6,16 @@ def test_yaml_defaults_loaded():
     assert config.SESSION_CONFIG['Asia']['start'] == '01:00'
     assert config.SNIPER_CONFIG_Q3_TUNED['tp1_pct'] == 0.7
     assert config.DEFAULT_RR1 == 1.2
+    # ตรวจสอบคีย์ใหม่ใน SNIPER_CONFIG_Q3_TUNED
+    assert config.SNIPER_CONFIG_Q3_TUNED['gain_z_thresh'] == 0.5
+    assert config.SNIPER_CONFIG_Q3_TUNED['atr_multiplier'] == 1.0
+    assert config.SNIPER_CONFIG_Q3_TUNED['rsi_oversold'] == 30
+    assert config.SNIPER_CONFIG_Q3_TUNED['rsi_overbought'] == 70
+    # ตรวจสอบคีย์ใหม่ใน RELAX_CONFIG_Q3
+    assert config.RELAX_CONFIG_Q3['gain_z_thresh'] == 0.3
+    assert config.RELAX_CONFIG_Q3['atr_multiplier'] == 0.8
+    assert config.RELAX_CONFIG_Q3['rsi_oversold'] == 35
+    assert config.RELAX_CONFIG_Q3['rsi_overbought'] == 65
 
 
 def test_env_override(monkeypatch):


### PR DESCRIPTION
## Summary
- expand `sniper_config_q3_tuned` and `relax_config_q3` settings
- test for new default keys
- document new patch in AGENTS and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d732393448325a76983abbc80f2d1