### PR TITLE
Apply entry and utils patches

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -1022,3 +1022,9 @@
 - [Patch vConfig v1.0] เพิ่มค่า config ใหม่ใน defaults.yaml
   - อัพเดต SNIPER_CONFIG_Q3_TUNED และ RELAX_CONFIG_Q3 พร้อมตัวแปร gain_z_thresh,
     atr_multiplier และ rsi limits
+
+### 2026-04-18
+- [Patch vEntry v1.0] สร้างคอลัมน์ side/is_dummy ใน generate_signals_v8_0 และ ForceEntry
+- [Patch vUtils v1.0] sanitize_price_columns รองรับ Titlecase, ensure_buy_sell เพิ่ม real trade
+- [Patch vML v1.0] ตรวจสอบฟีเจอร์สำคัญใน generate_ml_dataset_m1
+- [Patch vWFV v1.0] บันทึก equity summary ต่อ fold ใน run_walkforward_backtest

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -1022,3 +1022,9 @@
 - [Patch vConfig v1.0] เพิ่มค่า config ใหม่ใน defaults.yaml
 - ปรับ SNIPER_CONFIG_Q3_TUNED และ RELAX_CONFIG_Q3 ให้รองรับ gain_z_thresh,
   atr_multiplier และ rsi limits
+
+## 2026-04-18
+- [Patch vEntry v1.0] กำหนดคอลัมน์ side/is_dummy ใน generate_signals_v8_0 และ ForceEntry
+- [Patch vUtils v1.0] sanitize_price_columns รองรับ Titlecase และ ensure_buy_sell เพิ่ม trade จริง
+- [Patch vML v1.0] ตรวจสอบฟีเจอร์สำคัญ drop NaN ก่อนบันทึกชุดข้อมูล
+- [Patch vWFV v1.0] สรุป equity ต่อ fold และบันทึกเป็นไฟล์ CSV

--- a/nicegold_v5/tests/test_coverage_extra.py
+++ b/nicegold_v5/tests/test_coverage_extra.py
@@ -27,7 +27,13 @@ def test_generate_ml_dataset_alt_path(monkeypatch, tmp_path):
     alt_path = Path(mod_file).parent / 'does_not_exist.csv'
     make_sample_csv(alt_path)
     monkeypatch.setattr('nicegold_v5.entry.generate_signals', lambda df, config=None, **kw: df)
-    monkeypatch.setattr('nicegold_v5.exit.simulate_partial_tp_safe', lambda df, percentile_threshold=75: pd.DataFrame({'entry_time': df.index[:2], 'exit_reason': ['tp2', 'sl']}))
+    monkeypatch.setattr(
+        'nicegold_v5.exit.simulate_partial_tp_safe',
+        lambda df, percentile_threshold=75: pd.DataFrame({
+            'entry_time': df.index[:2],
+            'exit_reason': ['tp2'] * len(df.index[:2])
+        })
+    )
     out_csv = tmp_path / 'out.csv'
     generate_ml_dataset_m1('does_not_exist.csv', str(out_csv), mode="qa")
     assert out_csv.exists()


### PR DESCRIPTION
## Summary
- generate_signals_v8_0 now adds side/is_dummy columns
- sanitize_price_columns handles Titlecase and requires all price columns
- ensure_buy_sell injects a real trade when none exist
- ml dataset generator validates critical features
- walkforward backtest exports equity summary
- update tests for new behavior
- document changes in AGENTS and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d752b8d408325ab675beb77664643