### PR TITLE
Apply patch to production WFV

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -1028,3 +1028,7 @@
 - [Patch vUtils v1.0] sanitize_price_columns รองรับ Titlecase, ensure_buy_sell เพิ่ม real trade
 - [Patch vML v1.0] ตรวจสอบฟีเจอร์สำคัญใน generate_ml_dataset_m1
 - [Patch vWFV v1.0] บันทึก equity summary ต่อ fold ใน run_walkforward_backtest
+
+### 2026-04-19
+- [Patch vMain v1.0] เลือกใช้ config RELAX หาก Q3_TUNED ไม่มีสัญญาณ และบันทึกผล WFV
+- [Patch vBacktester v1.0] ปิด session_filter, ตั้งทุนเริ่มต้น และบันทึก equity curve

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -1028,3 +1028,7 @@
 - [Patch vUtils v1.0] sanitize_price_columns รองรับ Titlecase และ ensure_buy_sell เพิ่ม trade จริง
 - [Patch vML v1.0] ตรวจสอบฟีเจอร์สำคัญ drop NaN ก่อนบันทึกชุดข้อมูล
 - [Patch vWFV v1.0] สรุป equity ต่อ fold และบันทึกเป็นไฟล์ CSV
+
+## 2026-04-19
+- [Patch vMain v1.0] Fallback ใช้ RELAX_CONFIG_Q3 เมื่อไม่มี entry จาก Q3_TUNED
+- [Patch vBacktester v1.0] ปิด session_filter และบันทึก equity curve


### PR DESCRIPTION
## Summary
- enable config fallback in run_production_wfv and log equity results
- disable session filter in backtester and store equity curve
- update unit tests for new fallback logic
- document changes in AGENTS and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d79599bc08325bdf6cf14e52f857d