### PR TITLE
Fix KeyError for empty trade logs

### DIFF
--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -1048,3 +1048,8 @@
 - [Patch v32.2.1] Fix pass_filters timestamp handling
 - Updated unit tests for wfv
 - QA: pytest -q passed (264 tests)
+
+## 2026-04-23
+- [Patch v32.3.2] Ensure `is_dummy` column exists when no trades
+- Prevent KeyError in `run_production_wfv`
+- QA: pytest -q passed (264 tests)

--- a/nicegold_v5/wfv.py
+++ b/nicegold_v5/wfv.py
@@ -250,7 +250,9 @@ def run_walkforward_backtest(df, features, label_col, side='buy', n_folds=3, per
         print(f"[Strategy {strategy_name}] [Fold {fold+1} - {side.upper()}] Final Equity: {equity:.2f}")
 
     trades_df = pd.DataFrame(trades)
-    if not trades_df.empty:
+    if trades_df.empty:
+        trades_df["is_dummy"] = pd.Series(dtype=bool)
+    else:
         unique_reasons = set(trades_df.get("exit_reason", pd.Series(dtype=str)).str.lower().unique())
         expected = {"tp1", "tp2", "sl"}
         if not expected.issubset(unique_reasons):


### PR DESCRIPTION
## Summary
- ensure `run_walkforward_backtest` always returns an `is_dummy` column when trade logs are empty
- document fix in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d89a55db0832592f032d9f00d96b4