### PR TITLE
[Patch v34.0.0] Production WFV both sides

### DIFF
--- a/main.py
+++ b/main.py
@@ -992,7 +992,8 @@ def run_production_wfv():
         "[run_production_wfv] สรุปเบื้องต้น: Total Entries = %d", total_entries
     )
 
-    df_trades = run_walkforward_backtest(
+    # [Patch v34.0.0] รัน WFV ทั้งฝั่ง BUY และ SELL เพื่อให้ได้ออเดอร์ครบทั้งสองด้าน
+    df_trades_buy = run_walkforward_backtest(
         df,
         features=features,
         label_col="tp2_hit",
@@ -1001,6 +1002,16 @@ def run_production_wfv():
         percentile_threshold=75,
         strategy_name="ProdA",
     )
+    df_trades_sell = run_walkforward_backtest(
+        df,
+        features=features,
+        label_col="tp2_hit",
+        side="sell",
+        n_folds=3,
+        percentile_threshold=75,
+        strategy_name="ProdA",
+    )
+    df_trades = pd.concat([df_trades_buy, df_trades_sell], ignore_index=True)
 
     # [Patch v32.2.2] Guard กรณีไม่มีคอลัมน์ 'is_dummy' หรือ 'pnl'
     if df_trades.empty or "is_dummy" not in df_trades.columns or "pnl" not in df_trades.columns:

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -1094,3 +1094,9 @@
   - บังคับปิดสถานะที่ค้าง ณ ราคาปิดสุดท้ายด้วย exit_reason="eod_exit"
   - เพิ่ม unit test สำหรับกรณี EOD Exit
   - QA: pytest -q passed (269 tests)
+
+### 2026-05-02
+- [Patch v34.0.0] Production WFV runs BUY and SELL
+  - รัน run_walkforward_backtest ทั้งสองฝั่งและรวมผล
+  - เพิ่ม unit test ตรวจสอบฝั่ง BUY/SELL
+  - QA: pytest -q passed (270 tests)

--- a/nicegold_v5/tests/test_production_wfv.py
+++ b/nicegold_v5/tests/test_production_wfv.py
@@ -275,3 +275,43 @@ def test_run_production_wfv_empty_trades(monkeypatch):
     out = main.run_production_wfv()
 
     assert out.empty
+
+
+def test_run_production_wfv_both_sides(monkeypatch):
+    main = importlib.import_module('main')
+    df = pd.DataFrame({
+        'timestamp': pd.date_range('2025-01-01', periods=2, freq='min'),
+        'open': [1, 2],
+        'high': [1, 2],
+        'low': [1, 2],
+        'close': [1, 2],
+        'gain_z': [0.0, 0.0],
+        'ema_slope': [0.0, 0.0],
+        'atr': [1.0, 1.0],
+        'rsi': [50, 50],
+        'volume': [100, 100],
+        'entry_score': [0.1, 0.2],
+        'pattern_label': [1, 0],
+        'tp2_hit': [0, 1],
+    })
+    monkeypatch.setattr(main, 'load_csv_safe', lambda p: df)
+    monkeypatch.setattr(main, 'convert_thai_datetime', lambda d: d)
+    monkeypatch.setattr(main, 'parse_timestamp_safe', lambda s, fmt: s)
+    monkeypatch.setattr(main, 'sanitize_price_columns', lambda d: d)
+    monkeypatch.setattr(main, 'validate_indicator_inputs', lambda d, min_rows=None: None)
+    monkeypatch.setattr(main, 'check_exit_reason_variety', lambda df: True)
+    monkeypatch.setattr('nicegold_v5.entry.generate_signals_v8_0', lambda d, config=None: d.assign(entry_signal=['buy']*len(d)))
+
+    calls = []
+
+    def fake_run(df_in, *a, **kw):
+        calls.append(kw.get('side'))
+        return pd.DataFrame({'pnl': [0.0], 'side': [kw.get('side')], 'exit_reason': ['tp1'], 'is_dummy': [False]})
+
+    monkeypatch.setattr(main, 'run_walkforward_backtest', fake_run)
+    monkeypatch.setattr(main, 'auto_qa_after_backtest', lambda *a, **k: None)
+
+    result = main.run_production_wfv()
+
+    assert calls == ['buy', 'sell']
+    assert set(result['side']) == {'buy', 'sell'}


### PR DESCRIPTION
## Summary
- run `run_walkforward_backtest` for BUY and SELL in production workflow
- add unit test checking both sides
- document patch in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683da68591c08325be541cededbfe21c