### PR TITLE
Fix WFV trade log slice error

### DIFF
--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -1113,3 +1113,8 @@
   - เพิ่ม unit test `test_run_production_wfv_profit_boost`
   - QA: pytest -q passed (271 tests)
 
+### 2026-05-05
+- [Patch v34.3.0] Handle missing timestamps in build_trade_log
+  - slice window with sorted dates and fallback if index missing
+  - added unit test `test_build_trade_log_missing_index`
+  - QA: pytest -q passed (272 tests)

--- a/nicegold_v5/tests/test_build_trade_log_patch.py
+++ b/nicegold_v5/tests/test_build_trade_log_patch.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import nicegold_v5.wfv as wfv
+
+
+def test_build_trade_log_missing_index():
+    df = pd.DataFrame({'Open': [100, 101]}, index=pd.date_range('2025-01-01', periods=2, freq='h'))
+    position = {
+        'entry_time': pd.Timestamp('2025-01-01 03:00:00'),
+        'entry': 100.0,
+        'sl': 99.0,
+        'tp': 101.0,
+        'lot': 0.1,
+        'side': 'buy',
+        'commission': 0.0,
+    }
+    ts = pd.Timestamp('2025-01-01 04:00:00')
+    trade = wfv.build_trade_log(position, ts, 102.0, False, False, 1000.0, 0.0, df)
+    assert trade['mfe'] == 0.0


### PR DESCRIPTION
## Summary
- avoid index errors in `build_trade_log`
- test handling of missing timestamps
- document patch v34.3.0 in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683db86cb5048325998f910b168a74da