### PR TITLE
[Patch v34.4.0] Integrate GPU backtest

### DIFF
--- a/nicegold_v5/AGENTS.md
+++ b/nicegold_v5/AGENTS.md
@@ -220,3 +220,6 @@
 
 ---
 
+
+### 2026-05-06
+- **CHANGELOG:** Added v34.4.0 GPU backtest wrapper.

--- a/nicegold_v5/__init__.py
+++ b/nicegold_v5/__init__.py
@@ -89,3 +89,5 @@ except Exception:  # pragma: no cover - torch may be missing
     LSTMClassifier = None
     load_dataset = None
     train_lstm = None
+
+from .gpu_strategy import run_gpu_backtest

--- a/nicegold_v5/changelog.md
+++ b/nicegold_v5/changelog.md
@@ -1118,3 +1118,10 @@
   - slice window with sorted dates and fallback if index missing
   - added unit test `test_build_trade_log_missing_index`
   - QA: pytest -q passed (272 tests)
+
+### 2026-05-06
+- [Patch v34.4.0] GPU backtest wrapper
+  - added `gpu_strategy.py` implementing simplified order logic from gold ai gpu
+  - exported `run_gpu_backtest` in `__init__.py`
+  - added unit test `test_gpu_strategy_stub`
+  - QA: pytest -q passed (273 tests)

--- a/nicegold_v5/gpu_strategy.py
+++ b/nicegold_v5/gpu_strategy.py
@@ -1,0 +1,94 @@
+import pandas as pd
+from typing import Tuple, Dict, Any
+
+# [Patch v34.4.0] Simplified GPU backtest logic extracted from gold ai gpu.py
+
+def run_gpu_backtest(
+    df: pd.DataFrame,
+    label: str,
+    initial_capital: float,
+    side: str = "BUY",
+    fold_prob_threshold: float = 0.5,
+) -> Tuple[pd.DataFrame, pd.DataFrame, float, Dict[pd.Timestamp, float], float, Dict[str, Any], list, list]:
+    """Minimal order simulator inspired by gold ai gpu.py."""
+    df = df.copy()
+    df["Order_Opened"] = False
+    df["Equity_Realistic"] = initial_capital
+
+    equity = initial_capital
+    peak_equity = initial_capital
+    active_orders = []
+    trade_log = []
+    equity_history = {df.index[0]: initial_capital} if not df.empty else {}
+
+    for idx, row in df.iterrows():
+        new_orders = []
+        for order in active_orders:
+            exit_reason = None
+            exit_price = None
+            if order["side"] == "BUY":
+                if row["Low"] <= order["sl_price"]:
+                    exit_reason = "SL"
+                    exit_price = order["sl_price"]
+                elif row["High"] >= order["tp_price"]:
+                    exit_reason = "TP"
+                    exit_price = order["tp_price"]
+            else:
+                if row["High"] >= order["sl_price"]:
+                    exit_reason = "SL"
+                    exit_price = order["sl_price"]
+                elif row["Low"] <= order["tp_price"]:
+                    exit_reason = "TP"
+                    exit_price = order["tp_price"]
+
+            if exit_reason:
+                pnl = (exit_price - order["entry_price"]) if order["side"] == "BUY" else (order["entry_price"] - exit_price)
+                equity += pnl
+                trade_log.append({
+                    "entry_idx": order["entry_idx"],
+                    "exit_idx": idx,
+                    "side": order["side"],
+                    "exit_reason": exit_reason,
+                    "pnl": pnl,
+                })
+            else:
+                new_orders.append(order)
+        active_orders = new_orders
+
+        peak_equity = max(peak_equity, equity)
+
+        prob = row.get("Main_Prob_Live", 0.5)
+        if side == "BUY" and prob > fold_prob_threshold:
+            entry_price = row["Open"]
+            sl_price = entry_price - row["ATR_14_Shifted"] * row["SL_Multiplier"]
+            tp_price = entry_price + row["ATR_14_Shifted"] * row["TP_Multiplier"]
+            active_orders.append({
+                "entry_idx": idx,
+                "entry_price": entry_price,
+                "sl_price": sl_price,
+                "tp_price": tp_price,
+                "side": "BUY",
+            })
+            df.at[idx, "Order_Opened"] = True
+        elif side == "SELL" and prob < (1 - fold_prob_threshold):
+            entry_price = row["Open"]
+            sl_price = entry_price + row["ATR_14_Shifted"] * row["SL_Multiplier"]
+            tp_price = entry_price - row["ATR_14_Shifted"] * row["TP_Multiplier"]
+            active_orders.append({
+                "entry_idx": idx,
+                "entry_price": entry_price,
+                "sl_price": sl_price,
+                "tp_price": tp_price,
+                "side": "SELL",
+            })
+            df.at[idx, "Order_Opened"] = True
+
+        df.at[idx, "Equity_Realistic"] = equity
+        equity_history[idx] = equity
+
+    max_drawdown_pct = (peak_equity - equity) / peak_equity if peak_equity else 0.0
+    run_summary: Dict[str, Any] = {}
+    blocked_order_log: list = []
+    retrain_event_log: list = []
+    trades_df = pd.DataFrame(trade_log)
+    return df, trades_df, equity, equity_history, max_drawdown_pct, run_summary, blocked_order_log, retrain_event_log

--- a/nicegold_v5/tests/test_gpu_strategy.py
+++ b/nicegold_v5/tests/test_gpu_strategy.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from nicegold_v5.gpu_strategy import run_gpu_backtest
+
+
+def test_gpu_strategy_stub():
+    required_cols = [
+        'ATR_14_Shifted', 'Open', 'High', 'Low', 'Close', 'TP_Multiplier',
+        'SL_Multiplier', 'Volatility_Regime', 'Gain', 'ATR_14', 'RSI_14',
+        'Candle_Speed', 'VOL_50', 'MACD_hist', 'Gain_Z', 'ATR_14_Z',
+        'Candle_Ratio', 'MA_Filter_Active_Prev_Bar', 'MA_Filter_Active_Prev_Bar_Short',
+        'Override_MA_Filter', 'Override_MA_Filter_Short', 'Recovery_Buy_OK',
+        'Recovery_Sell_OK', 'Fold_Specific_Buy_OK', 'Fold_Specific_Sell_OK',
+        'Main_Prob_Live'
+    ]
+    data = {c: [0.0, 0.0, 0.0] for c in required_cols}
+    data['Open'] = [1800.0, 1801.0, 1802.0]
+    data['High'] = [1801.0, 1802.0, 1803.0]
+    data['Low'] = [1799.0, 1800.0, 1801.0]
+    data['Close'] = [1800.5, 1801.5, 1802.5]
+    data['ATR_14_Shifted'] = [1.0, 1.0, 1.0]
+    data['SL_Multiplier'] = [1.0, 1.0, 1.0]
+    data['TP_Multiplier'] = [1.0, 1.0, 1.0]
+    data['Main_Prob_Live'] = [0.6, 0.4, 0.7]
+    df = pd.DataFrame(data)
+    df.index = pd.date_range('2024-01-01', periods=3, freq='min')
+
+    result = run_gpu_backtest(df, 'Fold0', 1000.0, side='BUY', fold_prob_threshold=0.55)
+    trades = result[1]
+    assert not trades.empty


### PR DESCRIPTION
## Summary
- add `gpu_strategy.py` with simplified order logic from gold ai gpu
- export `run_gpu_backtest` in `__init__.py`
- add unit test for GPU strategy
- document GPU backtest wrapper in AGENTS and CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dc399b4c883258a86ae1ca5ee6e64